### PR TITLE
Fix Tolerate fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -460,7 +460,6 @@ class TolerateErrorsSession:
             return
         if len(self._tests) == 0:
             return
-        breakpoint()
         terminalreporter.ensure_newline()
         terminalreporter.write_line("")
         widths = {


### PR DESCRIPTION
This PR fixes a bug with the tolerate fixture and marker. 
It prevents the TolerateSession from printing a report if there are no marked tests