### PR TITLE
Fix release to TestPyPI from the develop branch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0-dev4
+current_version = 0.1.0-dev5
 commit = False
 tag = False
 allow_dirty = False

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     include_package_data=True,
-    version="0.1.0-dev4",
+    version="0.1.0-dev5",
     description="The python Data Valuation Library",
     install_requires=[
         line

--- a/src/valuation/__init__.py
+++ b/src/valuation/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.0-dev4"
+__version__ = "0.1.0-dev5"


### PR DESCRIPTION
This PR fixes the automated package from the develop branch to TestPyPI by bumping the version to match the latest version that it available on TestPyPI. This way when it is merged to develop it will be bumped to the next version automatically and the release would then work.