### PR TITLE
Parallelize test jobs

### DIFF
--- a/.github/workflows/run-tests-workflow.yaml
+++ b/.github/workflows/run-tests-workflow.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Cache Tox Directory for Tests
       uses: actions/cache@v3
       with:
-        key: tox-${{ runner.os }}-${{ hashFiles('tox.ini', 'requirements.txt') }}
+        key: tox-${{ github.ref }}-${{ runner.os }}-${{ hashFiles('tox.ini', 'requirements.txt') }}
         path: .tox
     - name: Run Tox
       run: tox

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Cache Tox Directory for Docs
         uses: actions/cache@v3
         with:
-          key: tox-${{ runner.os }}-${{ hashFiles('tox.ini') }}
+          key: tox-${{ github.ref }}-${{ runner.os }}-${{ hashFiles('tox.ini') }}
           path: .tox
       - name: Build Docs
         run: tox -e docs


### PR DESCRIPTION
This PR addresses issue #75.

- Creates reusable workflow for running tests.
- Puts the different test steps (default, torch, notebooks) in different jobs in order to run them in parallel by using the reusable workflow.
- Caches the `.tox` directory to speed up test runs in a given branch.
- Adds human-friendly names (more like descriptions) for all jobs 