### PR TITLE
Add warning to docstring and on runtime to batched_preconditioned_con…

### DIFF
--- a/build_scripts/update_docs.py
+++ b/build_scripts/update_docs.py
@@ -9,6 +9,7 @@ a repo containing multiple packages src/<package_1>, ...,  src/<package_n>.
 import logging
 import os
 import shutil
+from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +19,7 @@ def module_template(module_qualname: str):
     title = module_name.replace("_", r"\_")
     template = f"""{title}
 {"="*len(title)}
+
 .. automodule:: {module_qualname}
    :members:
    :undoc-members:
@@ -30,6 +32,7 @@ def package_template(package_qualname: str, *, add_toctree: bool = True):
     title = package_name.replace("_", r"\_")
     template = f"""{title}
 {"="*len(title)}
+
 .. automodule:: {package_qualname}
    :members:
    :undoc-members:
@@ -44,10 +47,12 @@ def package_template(package_qualname: str, *, add_toctree: bool = True):
     return template
 
 
-def index_template(package_name):
-    title = package_name.replace("_", r"\_")
+def index_template(package_name: str, title: Optional[str] = None) -> str:
+    if title is None:
+        title = package_name.replace("_", r"\_")
     template = f"""{title}
 {"="*len(title)}
+
 .. automodule:: {package_name}
    :members:
    :undoc-members:
@@ -93,7 +98,9 @@ def make_rst(src_root="src", docs_root="docs", clean=False, overwrite=False):
         ):
             continue
 
-        log.info(f"Generating docu for top-level package {top_level_package_name}")
+        log.info(
+            f"Generating documentation for top-level package {top_level_package_name}"
+        )
         top_level_package_docs_dir = os.path.join(docs_root, top_level_package_name)
         if clean and os.path.isdir(top_level_package_docs_dir):
             log.info(f"Deleting {top_level_package_docs_dir} since clean=True")
@@ -101,7 +108,9 @@ def make_rst(src_root="src", docs_root="docs", clean=False, overwrite=False):
 
         index_rst_path = os.path.join(docs_root, top_level_package_name, "index.rst")
         log.info(f"Creating {index_rst_path}")
-        write_to_file(index_template(top_level_package_name), index_rst_path)
+        write_to_file(
+            index_template(top_level_package_name, "API Reference"), index_rst_path
+        )
 
         for root, dirnames, filenames in os.walk(top_level_package_dir):
             if os.path.basename(root).startswith("_"):

--- a/docs/valuation/index.rst
+++ b/docs/valuation/index.rst
@@ -1,5 +1,6 @@
-valuation
-=========
+API Reference
+=============
+
 .. automodule:: valuation
    :members:
    :undoc-members:

--- a/src/valuation/influence/conjugate_gradient.py
+++ b/src/valuation/influence/conjugate_gradient.py
@@ -48,14 +48,15 @@ def batched_preconditioned_conjugate_gradient(
 ) -> Tuple["NDArray", int]:
     """
     Implementation of a batched conjugate gradient algorithm. It uses vector matrix products for efficient calculation.
-    See https://en.wikipedia.org/wiki/Conjugate_gradient_method for more details of the algorithm. See also
-    https://github.com/scipy/scipy/blob/v1.8.1/scipy/sparse/linalg/_isolve/iterative.py#L282-L351 and
-    https://web.stanford.edu/class/ee364b/lectures/conj_grad_slides.pdf. On top, it constrains the maximum step size.
+    On top of that, it constrains the maximum step size.
+
+    See [1]_ for more details on the algorithm.
+
+    See also [2]_ and [3]_.
 
     .. warning::
 
-        This function is unstable, and it is not recommended to use it.
-        Prefer using the simpler 'cg' method instead.
+        This function is experimental and unstable. Prefer using inversion_method='cg'
 
     :param A: A linear function f : R[k] -> R[k] representing a matrix vector product from dimension K to K or a matrix. \
         It has to be positive-definite v.T @ f(v) >= 0.
@@ -67,10 +68,14 @@ def batched_preconditioned_conjugate_gradient(
     :param verify_assumptions: True, iff the matrix should be checked for positive-definiteness by a stochastic rule.
 
     :return: A NDArray of shape [K] representing the solution of Ax=b.
+
+    .. note::
+        .. [1] `Conjugate Gradient Method - Wikipedia <https://en.wikipedia.org/wiki/Conjugate_gradient_method>`_.
+        .. [2] `SciPy's implementation of Conjugate Gradient <https://github.com/scipy/scipy/blob/v1.8.1/scipy/sparse/linalg/_isolve/iterative.py#L282-L351>`_.
+        .. [3] `Prof. Mert Pilanci., "Conjugate Gradient Method", Stanford University, 2022 <https://web.stanford.edu/class/ee364b/lectures/conj_grad_slides.pdf>`_.
     """
     warnings.warn(
-        "This function is unstable, and it is not recommended to use it. "
-        "Prefer using the simpler 'cg' method instead.",
+        "This function is experimental and unstable. Prefer using inversion_method='cg'",
         UserWarning,
     )
     # wrap A into a function.

--- a/src/valuation/utils/types.py
+++ b/src/valuation/utils/types.py
@@ -28,14 +28,17 @@ Scorer = Union[str, Callable[[SupervisedModel, ndarray, ndarray], float]]
 
 def unpackable(cls: Type) -> Type:
     """A class decorator that allows unpacking of all attributes of an object
-    with the double asterisk operator. E.g.::
-       @unpackable
-       @dataclass
-       class Schtuff:
-           a: int
-           b: str
-       x = Schtuff(a=1, b='meh')
-       d = dict(**x)
+    with the double asterisk operator.
+
+    :Example:
+
+    >>> @unpackable
+    ... @dataclass
+    ... class Schtuff:
+    ...    a: int
+    ...    b: str
+    >>> x = Schtuff(a=1, b='meh')
+    >>> d = dict(**x)
     """
 
     def keys(self):

--- a/src/valuation/utils/utility.py
+++ b/src/valuation/utils/utility.py
@@ -149,7 +149,6 @@ class DataUtilityLearning:
     :param training_budget: Number of utility samples to use for fitting the given model
     :param model: A supervised regression model
 
-
     :Example:
 
     >>> from valuation.utils import Utility, DataUtilityLearning, Dataset
@@ -167,8 +166,7 @@ class DataUtilityLearning:
     .. note::
         .. [1] `Tianhao Wang, Yu Yang, Ruoxi Jia.
            "Improving Cooperative Game Theory-based Data Valuation via Data Utility Learning."
-           arXiv, 2021
-           <https://arxiv.org/abs/2107.06336v2>`_.
+           arXiv, 2021 <https://arxiv.org/abs/2107.06336v2>`_.
     """
 
     def __init__(


### PR DESCRIPTION
This PR adds user-facing warnings when using the batched implementation of conjugate gradients.

It shows a user warning during runtime when the function is called.

It also adds a warning to the docstring of the function that is clearly visible in the docs. Here's what the warning looks like in the docs:

![image](https://user-images.githubusercontent.com/27914730/194301885-514d6b65-2dc2-46f6-bdd2-fb9e2c91f950.png)

**EDIT**: updated screenshot
