### PR TITLE
Add Binder links to notebook examples in Docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,6 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx_design",
     "nbsphinx",
-    "sphinx_gallery.load_style",
     # see https://github.com/spatialaudio/nbsphinx/issues/24 for an explanation why this extension is necessary
     "IPython.sphinxext.ipython_console_highlighting",
 ]


### PR DESCRIPTION
This PR addresses part of #74 by adding binder links to all notebook examples in the docs using nbsphinx.