### PR TITLE
Raise runtime error with advise to increase hessian perturbation

### DIFF
--- a/src/pydvl/influence/torch/torch_differentiable.py
+++ b/src/pydvl/influence/torch/torch_differentiable.py
@@ -530,8 +530,8 @@ def solve_linear(
         x = torch.linalg.solve(matrix, b.T).T
     except torch.linalg.LinAlgError as e:
         raise RuntimeError(
-            f"In case, you observe failure of the direct solver, due to singularity of the hessian matrix,"
-            f" consider to increase the parameter hessian_perturbation: \n{e}"
+            f"Direct inversion failed, possibly due to the Hessian being singular. "
+            f"Consider increasing the parameter 'hessian_perturbation' (currently: {hessian_perturbation}). \n{e}"
         )
     return InverseHvpResult(x=x, info=info)
 

--- a/src/pydvl/influence/torch/torch_differentiable.py
+++ b/src/pydvl/influence/torch/torch_differentiable.py
@@ -526,7 +526,14 @@ def solve_linear(
         model.num_params, device=model.device
     )
     info = {"hessian": hessian}
-    return InverseHvpResult(x=torch.linalg.solve(matrix, b.T).T, info=info)
+    try:
+        x = torch.linalg.solve(matrix, b.T).T
+    except torch.linalg.LinAlgError as e:
+        raise RuntimeError(
+            f"In case, you observe failure of the direct solver, due to singularity of the hessian matrix,"
+            f" consider to increase the parameter hessian_perturbation: \n{e}"
+        )
+    return InverseHvpResult(x=x, info=info)
 
 
 @InversionRegistry.register(TorchTwiceDifferentiable, InversionMethod.Cg)


### PR DESCRIPTION
### Description

This PR closes #447 

### Changes

- raise RuntimeError, with advice to increase hessian perturbation, when catching torch.linalg.LinalgError (due to singularity of the hessian) in direct solver

### Checklist

~~- [ ] Wrote Unit tests (if necessary)~~
~~- [ ] Updated Documentation (if necessary)~~
~~- [ ] Updated Changelog~~
~~- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~~
