### PR TITLE
Fix/loss ekfac

### DIFF
--- a/src/pydvl/influence/torch/functional.py
+++ b/src/pydvl/influence/torch/functional.py
@@ -407,6 +407,7 @@ def hessian(
     flat_params = flatten_dimensions(params.values())
 
     if use_hessian_avg:
+        n_samples = 0
         hessian = to_model_device(
             torch.zeros((n_parameters, n_parameters), dtype=model_dtype), model
         )
@@ -418,11 +419,12 @@ def hessian(
             return blf(align_with_model(p, model), t_x, t_y)
 
         for x, y in iter(data_loader):
-            hessian += torch.func.hessian(flat_input_batch_loss_function)(
+            n_samples += x.shape[0]
+            hessian += x.shape[0] * torch.func.hessian(flat_input_batch_loss_function)(
                 flat_params, to_model_device(x, model), to_model_device(y, model)
             )
 
-        hessian /= len(data_loader)
+        hessian /= n_samples
     else:
 
         def flat_input_empirical_loss(p: torch.Tensor):

--- a/src/pydvl/influence/torch/influence_function_model.py
+++ b/src/pydvl/influence/torch/influence_function_model.py
@@ -12,7 +12,7 @@ from typing import Callable, Dict, Optional, Tuple
 
 import torch
 from torch import nn as nn
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, TensorDataset
 from tqdm.auto import tqdm
 
 from pydvl.utils.progress import log_duration
@@ -892,7 +892,7 @@ class EkfacInfluence(TorchInfluenceFunctionModel):
         hessian_regularization: float = 0.0,
     ):
 
-        super().__init__(model, empirical_cross_entropy_loss_fn)
+        super().__init__(model, torch.nn.functional.cross_entropy)
         self.hessian_regularization = hessian_regularization
         self.active_layers = self._parse_active_layers()
 
@@ -984,7 +984,7 @@ class EkfacInfluence(TorchInfluenceFunctionModel):
         for x, _ in data:
             data_len += x.shape[0]
             pred_y = self.model(x)
-            loss = self.loss(pred_y)
+            loss = empirical_cross_entropy_loss_fn(pred_y)
             loss.backward()
 
         for key in forward_x.keys():

--- a/src/pydvl/influence/torch/influence_function_model.py
+++ b/src/pydvl/influence/torch/influence_function_model.py
@@ -1090,7 +1090,7 @@ class EkfacInfluence(TorchInfluenceFunctionModel):
         for x, _ in data:
             data_len += x.shape[0]
             pred_y = self.model(x)
-            loss = self.loss(pred_y)
+            loss = empirical_cross_entropy_loss_fn(pred_y)
             loss.backward()
 
         for key in diags.keys():

--- a/src/pydvl/influence/torch/util.py
+++ b/src/pydvl/influence/torch/util.py
@@ -456,7 +456,7 @@ class NestedTorchCatAggregator(NestedSequenceAggregator[torch.Tensor]):
         )
 
 
-@dataclass(frozen=True)
+@dataclass
 class EkfacRepresentation:
     r"""
     Container class for the EKFAC representation of the Hessian.


### PR DESCRIPTION

### Description

Fix loss usage in Ekfac implementation, different loss for gradient computation (cross-entropy) and Hessian
computation (empirical cross-entropy)

### Checklist

- [ ] Wrote Unit tests (if necessary)
- [ ] Updated Documentation (if necessary)
- [ ] Updated Changelog
- [ ] If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`
