### PR TITLE
Fix implementation of 'to' methods of TorchInfluenceFunctionModel imp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Bug in using `DaskInfluenceCalcualator` with `TorchnumpyConverter`
   for single dimensional arrays [PR #485](https://github.com/aai-institute/pyDVL/pull/485)
+- Fix implementations of `to` methods of `TorchInfluenceFunctionModel` implementations
+  [PR #487](https://github.com/aai-institute/pyDVL/pull/487)
 
 ## 0.8.0 - 🆕 New interfaces, scaling computation, bug fixes and improvements 🎁
 


### PR DESCRIPTION
…lementations

### Description

This PR closes #486 

### Changes

- fix the implementations of the `to` methods, which moves the influence function model to a device

### Checklist

- ~~[ ] Wrote Unit tests (if necessary)~~
- ~~[ ] Updated Documentation (if necessary)~~
- [x] Updated Changelog
- ~~[ ] If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~~
