### PR TITLE
Add parameter precompute_grad to CgInfluence init, adapt documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Bug in `LissaInfluence`, when not using CPU device [PR #495](https://github.com/aai-institute/pyDVL/pull/495)
+- Memory issue with `CgInfluence` and `ArnoldiInfluence`[PR #498](https://github.com/aai-institute/pyDVL/pull/498)
 
 ## 0.8.1 - 🆕 🏗  New method and noteboo, Games with exact shapley values, bug fixes and cleanup
 

--- a/src/pydvl/influence/torch/functional.py
+++ b/src/pydvl/influence/torch/functional.py
@@ -265,8 +265,8 @@ def create_hvp_function(
             is the model's input and the second element is the target output.
         precompute_grad: If True, the full data gradient is precomputed and kept
             in memory, which can speed up the hessian vector product computation.
-            Set this to False, if you can't afford to keep an additional
-            parameter-sized vector in memory.
+            Set this to False, if you can't afford to keep the full computation graph
+            in memory.
         use_average: If True, the returned function uses batch-wise computation via
             [batch_loss_function][pydvl.influence.torch.functional.batch_loss_function]
             and averages the results.

--- a/src/pydvl/influence/torch/functional.py
+++ b/src/pydvl/influence/torch/functional.py
@@ -772,6 +772,7 @@ def model_hessian_low_rank(
     tol: float = 1e-6,
     max_iter: Optional[int] = None,
     eigen_computation_on_gpu: bool = False,
+    precompute_grad: bool = False,
 ) -> LowRankProductRepresentation:
     r"""
     Calculates a low-rank approximation of the Hessian matrix of the model's
@@ -807,6 +808,10 @@ def model_hessian_low_rank(
             small rank_estimate to fit your device's memory.
             If False, the eigen pair approximation is executed on the CPU by
             scipy wrapper to ARPACK.
+        precompute_grad: If True, the full data gradient is precomputed and kept
+            in memory, which can speed up the hessian vector product computation.
+            Set this to False, if you can't afford to keep the full computation graph
+            in memory.
 
     Returns:
         [LowRankProductRepresentation]
@@ -814,7 +819,9 @@ def model_hessian_low_rank(
             instance that contains the top (up until rank_estimate) eigenvalues
             and corresponding eigenvectors of the Hessian.
     """
-    raw_hvp = create_hvp_function(model, loss, training_data, use_average=True)
+    raw_hvp = create_hvp_function(
+        model, loss, training_data, use_average=True, precompute_grad=precompute_grad
+    )
     n_params = sum([p.numel() for p in model.parameters() if p.requires_grad])
     device = next(model.parameters()).device
     return lanzcos_low_rank_hessian_approx(

--- a/src/pydvl/influence/torch/influence_function_model.py
+++ b/src/pydvl/influence/torch/influence_function_model.py
@@ -456,7 +456,7 @@ class CgInfluence(TorchInfluenceFunctionModel):
         atol: float = 1e-7,
         maxiter: Optional[int] = None,
         progress: bool = False,
-        precompute_grad: bool = True,
+        precompute_grad: bool = False,
     ):
         super().__init__(model, loss)
         self.precompute_grad = precompute_grad
@@ -760,6 +760,10 @@ class ArnoldiInfluence(TorchInfluenceFunctionModel):
             is appropriate for device memory.
             If False, the eigen pair approximation is executed on the CPU by the scipy
             wrapper to ARPACK.
+        precompute_grad: If True, the full data gradient is precomputed and kept
+            in memory, which can speed up the hessian vector product computation.
+            Set this to False, if you can't afford to keep the full computation graph
+            in memory.
     """
     low_rank_representation: LowRankProductRepresentation
 
@@ -773,6 +777,7 @@ class ArnoldiInfluence(TorchInfluenceFunctionModel):
         tol: float = 1e-6,
         max_iter: Optional[int] = None,
         eigen_computation_on_gpu: bool = False,
+        precompute_grad: bool = False,
     ):
 
         super().__init__(model, loss)
@@ -782,6 +787,7 @@ class ArnoldiInfluence(TorchInfluenceFunctionModel):
         self.max_iter = max_iter
         self.krylov_dimension = krylov_dimension
         self.eigen_computation_on_gpu = eigen_computation_on_gpu
+        self.precompute_grad = precompute_grad
 
     @property
     def is_fitted(self):
@@ -815,6 +821,7 @@ class ArnoldiInfluence(TorchInfluenceFunctionModel):
             tol=self.tol,
             max_iter=self.max_iter,
             eigen_computation_on_gpu=self.eigen_computation_on_gpu,
+            precompute_grad=self.precompute_grad,
         )
         self.low_rank_representation = low_rank_representation.to(self.model_device)
         return self


### PR DESCRIPTION
### Description

This PR closes #497

### Changes

- Expose the parameter `precopmute_grad`. Setting to False, results in the averaging of the second order derivatives over the batches, which requires less memory (no need to keep the computation graph) but is slower in general.


### Checklist

- [ ] ~~Wrote Unit tests (if necessary)~~
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- [ ] ~~If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~~
