### PR TITLE
Bump action version to avoid warnings in CI

### DIFF
--- a/.github/actions/python/action.yml
+++ b/.github/actions/python/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
   - name: Set up Python ${{ inputs.python_version }}
-    uses: actions/setup-python@v4
+    uses: actions/setup-python@v5
     with:
       python-version: ${{ inputs.python_version }}
       cache: 'pip'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,12 +24,12 @@ jobs:
     name: Lint code and check type hints
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup Python 3.8
       uses: ./.github/actions/python
       with:
         python_version: 3.8
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit
         key: pre-commit-${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -43,17 +43,18 @@ jobs:
       run: |
         MYPY_VERSION=$(mypy --version | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
         echo "key=mypy-$MYPY_VERSION-${{ env.pythonLocation }}" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: .mypy_cache
         key: ${{ steps.generate-mypy-cache-key.outputs.key }}
     - name: Check Type Hints
       run: mypy src/
+
   docs:
     name: Build Docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup Python 3.8
@@ -66,6 +67,7 @@ jobs:
         pandoc-version: ${{ env.PANDOC_VERSION }}
     - name: Build Docs
       run: mkdocs build
+
   group-tests:
     strategy:
       fail-fast: false
@@ -79,6 +81,7 @@ jobs:
       group_number: ${{ matrix.group_number }}
       python_version: ${{ matrix.python_version }}
     needs: [code-quality]
+
   notebook-tests:
     strategy:
       matrix:
@@ -88,6 +91,7 @@ jobs:
     with:
       python_version: ${{ matrix.python_version }}
     needs: [code-quality]
+
   push-docs-and-release-testpypi:
     name: Push Docs and maybe release Package to TestPyPI
     runs-on: ubuntu-latest
@@ -96,7 +100,7 @@ jobs:
     concurrency:
       group: publish
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python 3.8
         uses: ./.github/actions/python
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - name: Checking out last commit in release
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checking out last commit for tag ${{ inputs.tag_name }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           ref: ${{ inputs.tag_name }}

--- a/.github/workflows/run-notebook-tests-workflow.yaml
+++ b/.github/workflows/run-notebook-tests-workflow.yaml
@@ -15,7 +15,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup Python ${{ inputs.python_version }}
@@ -23,7 +23,7 @@ jobs:
       with:
         python_version: ${{ inputs.python_version }}
     - name: Cache Tox Directory for Tests
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: tox-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('tox.ini', 'requirements.txt') }}-${{ inputs.python_version }}
         path: .tox

--- a/.github/workflows/run-tests-workflow.yaml
+++ b/.github/workflows/run-tests-workflow.yaml
@@ -23,7 +23,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup Python ${{ inputs.python_version }}
@@ -31,7 +31,7 @@ jobs:
       with:
         python_version: ${{ inputs.python_version }}
     - name: Cache Tox Directory for Tests
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: tox-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('tox.ini', 'requirements.txt') }}-${{ inputs.python_version }}
         path: .tox
@@ -40,7 +40,7 @@ jobs:
     - name: Test Group ${{ inputs.group_number }}
       run: tox -e tests -- --slow-tests --splits ${{ inputs.split_size }} --group ${{ inputs.group_number }}
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v9
         with:
           only-labels: 'awaiting-reply'
           days-before-stale: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 - Bug in `LissaInfluence`, when not using CPU device [PR #495](https://github.com/aai-institute/pyDVL/pull/495)
 
-## 0.8.1 - 🆕 🏗  New method and noteboo, Games with exact shapley values, bug fixes and cleanup
+### Miscellaneous
+
+- Bump versions of CI actions to avoid warnings [PR #502](https://github.com/aai-institute/pyDVL/pull/502)
+
+## 0.8.1 - 🆕 🏗  New method and notebook, Games with exact shapley values, bug fixes and cleanup
 
 ### Added
 


### PR DESCRIPTION
### Description

This PR bumps versions of actions in CI to avoid warning messages related to Github's deprecation of Node 16.

![image](https://github.com/aai-institute/pyDVL/assets/27914730/f6496e0c-507b-4ead-b0f2-951e990df248)


### Changes

- Bump actions/checkout from v3 to v4
- Bump actions/setup-python from v4 to v5
- Bump actions/cache from v3 to v4
- Bump actions/stale from v6 to v9

### Checklist

- [ ] ~Wrote Unit tests (if necessary)~
- [ ] ~Updated Documentation (if necessary)~
- [x] Updated Changelog
- [ ] ~If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~
