### PR TITLE
Fix/505 memcached documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 - Bug in `LissaInfluence`, when not using CPU device [PR #495](https://github.com/aai-institute/pyDVL/pull/495)
 - Memory issue with `CgInfluence` and `ArnoldiInfluence`[PR #498](https://github.com/aai-institute/pyDVL/pull/498)
+- Raising specific error message with install instruction, when trying to load `pydvl.utils.cache.memcached`
+  without `pymemcache` installed. If `pymemcache` is available, all symbols from
+  `pydvl.utils.cache.memcached` are available through `pydvl.utils.cache`[PR #509](https://github.com/aai-institute/pyDVL/pull/509)  
 
 ### Miscellaneous
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -87,4 +87,5 @@ that can be optionally installed:
     pip install pyDVL[memcached]
     ```
     
-    This installs [pymemcache](https://github.com/pinterest/pymemcache) additionally.
+    This installs [pymemcache](https://github.com/pinterest/pymemcache) additionally. 
+    Be aware, that you still have to start a memcached server manually.

--- a/src/pydvl/influence/array.py
+++ b/src/pydvl/influence/array.py
@@ -8,10 +8,11 @@ using the Zarr library.
 """
 
 from abc import ABC, abstractmethod
-from typing import Callable, Generator, Generic, List, Optional, Tuple
+from typing import Callable, Generator, Generic, List, Optional, Tuple, Union
 
 import zarr
 from numpy.typing import NDArray
+from zarr.storage import StoreLike
 
 from .base_influence_function_model import TensorType
 
@@ -140,7 +141,7 @@ class LazyChunkSequence:
 
     def to_zarr(
         self,
-        path_or_url: str,
+        path_or_url: Union[str, StoreLike],
         converter: NumpyConverter,
         return_stored: bool = False,
         overwrite: bool = False,
@@ -153,6 +154,7 @@ class LazyChunkSequence:
 
         Args:
             path_or_url: The file path or URL where the Zarr array will be stored.
+                Also excepts instances of zarr stores.
             converter: A converter for transforming blocks into NumPy arrays
                 compatible with Zarr.
             return_stored: If True, the method returns the stored Zarr array; otherwise,
@@ -244,7 +246,7 @@ class NestedLazyChunkSequence:
 
     def to_zarr(
         self,
-        path_or_url: str,
+        path_or_url: Union[str, StoreLike],
         converter: NumpyConverter,
         return_stored: bool = False,
         overwrite: bool = False,
@@ -257,6 +259,7 @@ class NestedLazyChunkSequence:
 
         Args:
             path_or_url: The file path or URL where the Zarr array will be stored.
+                Also excepts instances of zarr stores.
             converter: A converter for transforming blocks into NumPy arrays
                 compatible with Zarr.
             return_stored: If True, the method returns the stored Zarr array;

--- a/src/pydvl/utils/caching/__init__.py
+++ b/src/pydvl/utils/caching/__init__.py
@@ -88,7 +88,5 @@ from .memory import *
 
 try:
     from .memcached import *
-
-    PYMEMCACHE_INSTALLED = True
 except ModuleNotFoundError:
-    PYMEMCACHE_INSTALLED = False
+    pass

--- a/src/pydvl/utils/caching/__init__.py
+++ b/src/pydvl/utils/caching/__init__.py
@@ -84,5 +84,11 @@ functions distinct to the eyes of the cache. This can be avoided with the use of
 from .base import *
 from .config import *
 from .disk import *
-from .memcached import *
 from .memory import *
+
+try:
+    from .memcached import *
+
+    PYMEMCACHE_INSTALLED = True
+except ModuleNotFoundError:
+    PYMEMCACHE_INSTALLED = False

--- a/src/pydvl/utils/caching/memcached.py
+++ b/src/pydvl/utils/caching/memcached.py
@@ -9,10 +9,13 @@ try:
     from pymemcache import MemcacheUnexpectedCloseError
     from pymemcache.client import Client, RetryingClient
     from pymemcache.serde import PickleSerde
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        f"Cannot use MemcachedCacheBackend because pymemcache was not installed. "
+        f"Make sure to install pyDVL using `pip install pyDVL[memcached]`. \n"
+        f"Original error: {e}"
+    )
 
-    PYMEMCACHE_INSTALLED = True
-except ImportError:
-    PYMEMCACHE_INSTALLED = False
 
 from .base import CacheBackend
 
@@ -103,11 +106,7 @@ class MemcachedCacheBackend(CacheBackend):
         Args:
             config: Memcached client configuration.
         """
-        if not PYMEMCACHE_INSTALLED:
-            raise ModuleNotFoundError(
-                "Cannot use MemcachedCacheBackend because pymemcache was not installed. "
-                "Make sure to install pyDVL using `pip install pyDVL[memcached]`"
-            )
+
         super().__init__()
         self.config = config
         self.client = self._connect(self.config)

--- a/tests/influence/test_influence_calculator.py
+++ b/tests/influence/test_influence_calculator.py
@@ -1,11 +1,10 @@
-import logging
-import shutil
 import uuid
 
 import dask.array as da
 import numpy as np
 import pytest
 import torch
+import zarr
 from distributed import Client
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
@@ -275,7 +274,7 @@ def test_thread_safety_violation_error(
         )
 
 
-def test_sequential_calculator(model_and_data, test_case):
+def test_sequential_calculator(model_and_data, test_case, mocker):
     model, loss, x_train, y_train, x_test, y_test = model_and_data
     train_dataloader = DataLoader(
         TensorDataset(x_train, y_train), batch_size=test_case.batch_size
@@ -296,13 +295,15 @@ def test_sequential_calculator(model_and_data, test_case):
     seq_factors = seq_factors_lazy_array.compute(aggregator=TorchCatAggregator())
 
     torch_factors = inf_model.influence_factors(x_test, y_test)
-    zarr_factors_path = str(uuid.uuid4())
+
+    zarr_factors_store = zarr.MemoryStore()
     seq_factors_from_zarr = seq_factors_lazy_array.to_zarr(
-        zarr_factors_path, TorchNumpyConverter(), return_stored=True
+        zarr_factors_store, TorchNumpyConverter(), return_stored=True
     )
+
     assert torch.allclose(seq_factors, torch_factors, atol=1e-6)
-    assert np.allclose(torch_factors.numpy(), seq_factors_from_zarr, atol=1e-6)
-    shutil.rmtree(zarr_factors_path)
+    assert np.allclose(seq_factors_from_zarr, torch_factors, atol=1e-6)
+    del zarr_factors_store
 
     torch_values_from_factors = inf_model.influences_from_factors(
         torch_factors, x_train, y_train, mode=test_case.mode
@@ -320,24 +321,25 @@ def test_sequential_calculator(model_and_data, test_case):
     seq_values_from_factors = seq_values_from_factors_lazy_array.compute(
         aggregator=NestedTorchCatAggregator()
     )
-    zarr_values_from_factors_path = str(uuid.uuid4())
+    zarr_values_from_factors_store = zarr.MemoryStore()
     seq_values_from_factors_from_zarr = seq_values_from_factors_lazy_array.to_zarr(
-        zarr_values_from_factors_path, TorchNumpyConverter(), return_stored=True
+        zarr_values_from_factors_store, TorchNumpyConverter(), return_stored=True
     )
 
     assert torch.allclose(seq_values_from_factors, torch_values_from_factors, atol=1e-6)
     assert np.allclose(
         seq_values_from_factors_from_zarr, torch_values_from_factors.numpy(), atol=1e-6
     )
-    shutil.rmtree(zarr_values_from_factors_path)
+    del zarr_values_from_factors_store
 
     seq_values_lazy_array = seq_calculator.influences(
         test_dataloader, train_dataloader, mode=test_case.mode
     )
     seq_values = seq_values_lazy_array.compute(aggregator=NestedTorchCatAggregator())
-    zarr_values_path = str(uuid.uuid4())
+
+    zarr_values_store = zarr.MemoryStore()
     seq_values_from_zarr = seq_values_lazy_array.to_zarr(
-        zarr_values_path, TorchNumpyConverter(), return_stored=True
+        zarr_values_store, TorchNumpyConverter(), return_stored=True
     )
 
     torch_values = inf_model.influences(
@@ -345,7 +347,7 @@ def test_sequential_calculator(model_and_data, test_case):
     )
     assert torch.allclose(seq_values, torch_values, atol=1e-6)
     assert np.allclose(seq_values_from_zarr, torch_values.numpy(), atol=1e-6)
-    shutil.rmtree(zarr_values_path)
+    del zarr_values_store
 
 
 @pytest.mark.torch

--- a/tests/utils/test_caching.py
+++ b/tests/utils/test_caching.py
@@ -3,6 +3,7 @@ import pickle
 import tempfile
 from time import sleep, time
 from typing import Optional
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import numpy as np
 import pytest
@@ -154,9 +155,15 @@ def test_single_job(cache_backend):
 
 
 def test_without_pymemcache(mocker):
-    mocker.patch("pydvl.utils.caching.memcached.PYMEMCACHE_INSTALLED", False)
-    with pytest.raises(ModuleNotFoundError):
-        MemcachedCacheBackend()
+    import importlib
+    import sys
+
+    mocker.patch.dict("sys.modules", {"pymemcache": None})
+    with pytest.raises(ModuleNotFoundError) as err:
+        importlib.reload(sys.modules["pydvl.utils.caching.memcached"])
+
+    # error message should contain the extra install expression
+    assert "pyDVL[memcached]" in err.value.msg
 
 
 def test_memcached_failed_connection():


### PR DESCRIPTION
### Description

This PR closes #505 

### Changes

- Raising specific error message with install instruction, when trying to load `pydvl.utils.cache.memcached`
  without `pymemcache` installed. If `pymemcache` is available, all symbols from
  `pydvl.utils.cache.memcached` are available through `pydvl.utils.cache


### Checklist

- [x] Wrote Unit tests (if necessary)
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- [x] ~If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~
