### PR TITLE
Add support for Python Version 3.11

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -85,7 +85,7 @@ jobs:
   notebook-tests:
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10"]
+        python_version: ["3.8", "3.9", "3.10", "3.11"]
     name: Run Notebook tests -  Python ${{ matrix.python_version }}
     uses: ./.github/workflows/run-notebook-tests-workflow.yaml
     with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.8", "3.9", "3.10"]
+        python_version: ["3.8", "3.9", "3.10", "3.11"]
         group_number: [1, 2, 3, 4]
     name: Run Tests - Python ${{ matrix.python_version }} - Group ${{ matrix.group_number }}
     uses: ./.github/workflows/run-tests-workflow.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Miscellaneous
 
 - Bump versions of CI actions to avoid warnings [PR #502](https://github.com/aai-institute/pyDVL/pull/502)
+- Add Python Version 3.11 to supported versions [PR #510](https://github.com/aai-institute/pyDVL/pull/510)
 
 ## 0.8.1 - 🆕 🏗  New method and notebook, Games with exact shapley values, bug fixes and cleanup
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,8 @@ tox-wheel
 pre-commit==3.1.1
 black[jupyter] == 23.1.0
 isort == 5.12.0
-pylint==2.12.0
-pylint-json2html
+pylint==3.1.0
+pylint-json2html==0.5.0
 anybadge
 mypy==1.5.1
 types-tqdm

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Typing :: Typed",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
<!--
Thanks for making a contribution! 
Please make sure you have read the contributing guide: 
https://github.com/aai-institute/pyDVL/blob/develop/CONTRIBUTING.md
-->

### Description
Python 3.11 is now 1.5 years old and needs to be supported urgently.

This PR closes #296 

### Changes

- Add Python 3.11 to supported language versions and test matrix.

### Checklist

- [x] Wrote Unit tests (if necessary)
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- [x] If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`
