### PR TITLE
Simplify parallel backend config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 - Documentation improvements and cleanup
   [PR #521](https://github.com/aai-institute/pyDVL/pull/521),
   [PR #522](https://github.com/aai-institute/pyDVL/pull/522)
+- Simplified parallel backend configuration
+  [PR #549](https://github.com/mkdocstrings/mkdocstrings/issues/615)
 
 ## 0.8.1 - 🆕 🏗  New method and notebook, Games with exact shapley values, bug fixes and cleanup
 

--- a/docs/getting-started/advanced-usage.md
+++ b/docs/getting-started/advanced-usage.md
@@ -48,18 +48,23 @@ to compute exact shapley values you would use:
 
 ```python
 import joblib
-from pydvl.parallel import ParallelConfig
+from pydvl.parallel import JoblibParallelBackend
 from pydvl.value.shapley import combinatorial_exact_shapley
 from pydvl.utils.utility import Utility
 
-config = ParallelConfig(backend="joblib") 
+parallel_backend = JoblibParallelBackend() 
 u = Utility(...)
 
 with joblib.parallel_config(backend="loky", verbose=100):
-    combinatorial_exact_shapley(u, config=config)
+    values = combinatorial_exact_shapley(u, parallel_backend=parallel_backend)
 ```
 
 #### Ray
+
+!!! info
+   
+    The Ray parallel backend requires optional dependencies.
+    See [Extras][installation-extras] for more information.
 
 Please follow the instructions in Ray's documentation to
 [set up a remote cluster](https://docs.ray.io/en/latest/cluster/key-concepts.html).
@@ -90,14 +95,14 @@ To use the ray parallel backend to compute exact shapley values you would use:
 
 ```python
 import ray
-from pydvl.parallel import ParallelConfig
+from pydvl.parallel import RayParallelBackend
 from pydvl.value.shapley import combinatorial_exact_shapley
 from pydvl.utils.utility import Utility
 
 ray.init()
-config = ParallelConfig(backend="ray")
+parallel_backend = RayParallelBackend()
 u = Utility(...)
-combinatorial_exact_shapley(u, config=config)
+vaues = combinatorial_exact_shapley(u, parallel_backend=parallel_backend)
 ```
 
 ### Influence functions

--- a/docs/getting-started/advanced-usage.md
+++ b/docs/getting-started/advanced-usage.md
@@ -57,7 +57,7 @@ parallel_backend = init_parallel_backend(backend_name="joblib")
     of pyDVL. They are used internally as part of the computations of the 
     different methods.
 
-!!! info
+!!! danger "Deprecation notice"
 
     We are currently planning to deprecate
     [MapReduceJob][pydvl.parallel.map_reduce.MapReduceJob] in favour of the
@@ -88,7 +88,7 @@ with joblib.parallel_config(backend="loky", verbose=100):
 
 #### Ray
 
-!!! info
+!!! warning "Additional dependencies"
    
     The Ray parallel backend requires optional dependencies.
     See [Extras][installation-extras] for more information.
@@ -155,13 +155,13 @@ classes.
 [1, 2, 3]
 ```
 
-#### Map reduce
+#### Map-reduce
 
-The map reduce interface is older and more limited in the patterns
+The map-reduce interface is older and more limited in the patterns
 it allows us to use.
 
 To reproduce the previous example using
-[MapReduceJob][pydvl.parallel.map_reduce.MapReduceJob]we would use:
+[MapReduceJob][pydvl.parallel.map_reduce.MapReduceJob], we would use:
 
 ```pycon
 >>> from pydvl.parallel import JoblibParallelBackend, MapReduceJob

--- a/docs/getting-started/advanced-usage.md
+++ b/docs/getting-started/advanced-usage.md
@@ -42,6 +42,15 @@ of executors for the different algorithms: the first uses a map reduce pattern a
 the [MapReduceJob][pydvl.parallel.map_reduce.MapReduceJob] class
 and the second implements the futures executor interface from [concurrent.futures][].
 
+As a convenience, you can also instantiate a parallel backend class
+by using the [init_parallel_backend][pydvl.parallel.init_parallel_backend]
+function:
+
+```python
+from pydvl.parallel import init_parallel_backend
+parallel_backend = init_parallel_backend(backend_name="joblib")
+```
+
 !!! info
 
     The executor classes are not meant to be instantiated and used by users

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,7 @@ plugins:
       type: iso_date
       fallback_to_build_date: true
   - social:
+      enabled: false
       cards: !ENV [CI, True] # only build in CI
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,7 +141,6 @@ plugins:
       type: iso_date
       fallback_to_build_date: true
   - social:
-      enabled: false
       cards: !ENV [CI, True] # only build in CI
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ plugins:
             - https://pytorch.org/docs/stable/objects.inv
             - https://pymemcache.readthedocs.io/en/latest/objects.inv
             - https://joblib.readthedocs.io/en/stable/objects.inv
+            - https://loky.readthedocs.io/en/stable/objects.inv
             - https://docs.dask.org/en/latest/objects.inv
             - https://distributed.dask.org/en/latest/objects.inv
             - https://docs.ray.io/en/latest/objects.inv

--- a/src/pydvl/parallel/__init__.py
+++ b/src/pydvl/parallel/__init__.py
@@ -1,37 +1,37 @@
 """
 This module provides a common interface to parallelization backends. The list of
-supported backends is [here][pydvl.parallel.backends]. Backends can be
-selected with the `backend` argument of an instance of
-[ParallelConfig][pydvl.utils.config.ParallelConfig], as seen in the examples
-below.
+supported backends is [here][pydvl.parallel.backends]. Backends should be
+instantiated directly and passed to the respective valuation method.
 
-We use [executors][concurrent.futures.Executor] to submit tasks in parallel. The
-basic high-level pattern is
+We use executors that implement the [Executor][concurrent.futures.Executor]
+interface to submit tasks in parallel.
+The basic high-level pattern is:
 
 ```python
-from pydvl.parallel import init_executor, ParallelConfig
+from pydvl.parallel import JoblibParallelBackend
 
-config = ParallelConfig(backend="ray")
-with init_executor(max_workers=1, config=config) as executor:
+parallel_backend = JoblibParallelBackend()
+with parallel_backend.executor(max_workers=2) as executor:
     future = executor.submit(lambda x: x + 1, 1)
     result = future.result()
 assert result == 2
 ```
 
-Running a map-reduce job is also easy:
+Running a map-style job is also easy:
 
 ```python
-from pydvl.parallel import init_executor, ParallelConfig
+from pydvl.parallel import JoblibParallelBackend
 
-config = ParallelConfig(backend="joblib")
-with init_executor(config=config) as executor:
+parallel_backend = JoblibParallelBackend()
+with parallel_backend.executor(max_workers=2) as executor:
     results = list(executor.map(lambda x: x + 1, range(5)))
 assert results == [1, 2, 3, 4, 5]
 ```
 
 There is an alternative map-reduce implementation
 [MapReduceJob][pydvl.parallel.map_reduce.MapReduceJob] which internally
-uses joblib's higher level API with `Parallel()`
+uses joblib's higher level API with `Parallel()` which then indirectly also
+supports the use of Dask and Ray.
 """
 # HACK to avoid circular imports
 from ..utils.types import *  # pylint: disable=wrong-import-order

--- a/src/pydvl/parallel/__init__.py
+++ b/src/pydvl/parallel/__init__.py
@@ -41,5 +41,5 @@ from .config import *
 from .futures import *
 from .map_reduce import *
 
-if len(BaseParallelBackend.BACKENDS) == 0:
+if len(ParallelBackend.BACKENDS) == 0:
     raise ImportError("No parallel backend found. Please install ray or joblib.")

--- a/src/pydvl/parallel/__init__.py
+++ b/src/pydvl/parallel/__init__.py
@@ -27,7 +27,18 @@ with parallel_backend.executor(max_workers=2) as executor:
     results = list(executor.map(lambda x: x + 1, range(5)))
 assert results == [1, 2, 3, 4, 5]
 ```
-
+!!! tip "Passsing large objects"
+    When running tasks which accept heavy inputs, it is important
+    to first use `put()` on the object and use the returned reference
+    as argument to the callable within `submit()`. For example:    
+    ```python
+    u_ref = parallel_backend.put(u)
+    ...
+    executor.submit(task, utility=u)
+    ```
+    Note that `task()` does not need to be changed in any way:
+    the backend will `get()` the object and pass it to the function
+    upon invocation.
 There is an alternative map-reduce implementation
 [MapReduceJob][pydvl.parallel.map_reduce.MapReduceJob] which internally
 uses joblib's higher level API with `Parallel()` which then indirectly also

--- a/src/pydvl/parallel/backend.py
+++ b/src/pydvl/parallel/backend.py
@@ -197,7 +197,8 @@ def effective_n_jobs(n_jobs: int, config: ParallelConfig = ParallelConfig()) -> 
             is < 1.
     """
     parallel_backend = init_parallel_backend(config)
-    if (eff_n_jobs := parallel_backend.effective_n_jobs(n_jobs)) < 1:
+    eff_n_jobs: int = parallel_backend.effective_n_jobs(n_jobs)
+    if eff_n_jobs < 1:
         raise RuntimeError(
             f"Invalid number of jobs {eff_n_jobs} obtained from parallel backend {config.backend}"
         )

--- a/src/pydvl/parallel/backend.py
+++ b/src/pydvl/parallel/backend.py
@@ -6,7 +6,7 @@ import warnings
 from abc import abstractmethod
 from concurrent.futures import Executor
 from enum import Flag, auto
-from typing import Any, Callable, Optional, Type, Union
+from typing import Any, Callable, Type
 
 from deprecate import deprecated
 
@@ -57,10 +57,10 @@ class ParallelBackend:
     @abstractmethod
     def executor(
         cls,
-        max_workers: Optional[int] = None,
+        max_workers: int | None = None,
         *,
-        config: Optional[ParallelConfig] = None,
-        cancel_futures: Union[CancellationPolicy, bool] = CancellationPolicy.PENDING,
+        config: ParallelConfig | None = None,
+        cancel_futures: CancellationPolicy | bool = CancellationPolicy.PENDING,
     ) -> Executor:
         """Returns a futures executor for the parallel backend."""
         ...
@@ -139,8 +139,8 @@ def init_parallel_backend(config: ParallelConfig) -> ParallelBackend:
 # This string for the benefit of deprecation searches:
 # remove_in="0.10.0"
 def _maybe_init_parallel_backend(
-    parallel_backend: Optional[ParallelBackend] = None,
-    config: Optional[ParallelConfig] = None,
+    parallel_backend: ParallelBackend | None = None,
+    config: ParallelConfig | None = None,
 ) -> ParallelBackend:
     """Helper function inside during the deprecation period of
     [][pydvl.parallel.backend.init_parallel_backend] and should be removed in v0.10.0

--- a/src/pydvl/parallel/backend.py
+++ b/src/pydvl/parallel/backend.py
@@ -15,7 +15,6 @@ from .config import ParallelConfig
 __all__ = [
     "init_parallel_backend",
     "_maybe_init_parallel_backend",
-    "effective_n_jobs",
     "available_cpus",
     "ParallelBackend",
     "CancellationPolicy",
@@ -175,31 +174,3 @@ def available_cpus() -> int:
     if system() != "Linux":
         return os.cpu_count() or 1
     return len(os.sched_getaffinity(0))  # type: ignore
-
-
-def effective_n_jobs(n_jobs: int, config: ParallelConfig = ParallelConfig()) -> int:
-    """Returns the effective number of jobs.
-
-    This number may vary depending on the parallel backend and the resources
-    available.
-
-    Args:
-        n_jobs: the number of jobs requested. If -1, the number of available
-            CPUs is returned.
-        config: instance of [ParallelConfig][pydvl.utils.config.ParallelConfig] with
-            cluster address, number of cpus, etc.
-
-    Returns:
-        The effective number of jobs, guaranteed to be >= 1.
-
-    Raises:
-        RuntimeError: if the effective number of jobs returned by the backend
-            is < 1.
-    """
-    parallel_backend = init_parallel_backend(config)
-    eff_n_jobs: int = parallel_backend.effective_n_jobs(n_jobs)
-    if eff_n_jobs < 1:
-        raise RuntimeError(
-            f"Invalid number of jobs {eff_n_jobs} obtained from parallel backend {config.backend}"
-        )
-    return eff_n_jobs

--- a/src/pydvl/parallel/backend.py
+++ b/src/pydvl/parallel/backend.py
@@ -7,6 +7,8 @@ from concurrent.futures import Executor
 from enum import Flag, auto
 from typing import Any, Callable, Type
 
+from deprecate import deprecated
+
 from .config import ParallelConfig
 
 __all__ = [
@@ -91,6 +93,11 @@ class BaseParallelBackend:
         return f"<{self.__class__.__name__}: {self.config}>"
 
 
+@deprecated(
+    target=None,
+    remove_in="0.10.0",
+    deprecated_in="0.9.0",
+)
 def init_parallel_backend(config: ParallelConfig) -> BaseParallelBackend:
     """Initializes the parallel backend and returns an instance of it.
 

--- a/src/pydvl/parallel/backend.py
+++ b/src/pydvl/parallel/backend.py
@@ -14,7 +14,7 @@ from .config import ParallelConfig
 
 __all__ = [
     "init_parallel_backend",
-    "maybe_init_parallel_backend",
+    "_maybe_init_parallel_backend",
     "effective_n_jobs",
     "available_cpus",
     "ParallelBackend",
@@ -139,7 +139,7 @@ def init_parallel_backend(config: ParallelConfig) -> ParallelBackend:
 # TODO: delete this class once it's made redundant in v0.10.0
 # This string for the benefit of deprecation searches:
 # remove_in="0.10.0"
-def maybe_init_parallel_backend(
+def _maybe_init_parallel_backend(
     parallel_backend: Optional[ParallelBackend] = None,
     config: Optional[ParallelConfig] = None,
 ) -> ParallelBackend:

--- a/src/pydvl/parallel/backend.py
+++ b/src/pydvl/parallel/backend.py
@@ -133,7 +133,7 @@ def init_parallel_backend(config: ParallelConfig) -> ParallelBackend:
         parallel_backend_cls = ParallelBackend.BACKENDS[config.backend]
     except KeyError:
         raise NotImplementedError(f"Unexpected parallel backend {config.backend}")
-    return parallel_backend_cls.create(config)  # type: ignore
+    return parallel_backend_cls(config)  # type: ignore
 
 
 # TODO: delete this class once it's made redundant in v0.10.0

--- a/src/pydvl/parallel/backend.py
+++ b/src/pydvl/parallel/backend.py
@@ -7,7 +7,6 @@ from concurrent.futures import Executor
 from enum import Flag, auto
 from typing import Any, Callable, Type
 
-from ..utils.types import NoPublicConstructor
 from .config import ParallelConfig
 
 __all__ = [
@@ -41,7 +40,7 @@ class CancellationPolicy(Flag):
     ALL = PENDING | RUNNING
 
 
-class BaseParallelBackend(metaclass=NoPublicConstructor):
+class BaseParallelBackend:
     """Abstract base class for all parallel backends."""
 
     config: dict[str, Any] = {}

--- a/src/pydvl/parallel/backend.py
+++ b/src/pydvl/parallel/backend.py
@@ -63,7 +63,7 @@ class ParallelBackend:
         config: Optional[ParallelConfig] = None,
         cancel_futures: Union[CancellationPolicy, bool] = CancellationPolicy.PENDING,
     ) -> Executor:
-        """Returns an executor for the parallel backend."""
+        """Returns a futures executor for the parallel backend."""
         ...
 
     @abstractmethod

--- a/src/pydvl/parallel/backend.py
+++ b/src/pydvl/parallel/backend.py
@@ -96,15 +96,38 @@ class ParallelBackend:
 
 
 @deprecated(
-    target=None,
-    remove_in="0.10.0",
+    target=True,
+    args_mapping={"config": "config"},
     deprecated_in="0.9.0",
+    remove_in="0.10.0",
 )
-def init_parallel_backend(config: ParallelConfig) -> ParallelBackend:
+def init_parallel_backend(
+    config: ParallelConfig | None = None, backend_name: str | None = None
+) -> ParallelBackend:
     """Initializes the parallel backend and returns an instance of it.
 
     The following example creates a parallel backend instance with the default
     configuration, which is a local joblib backend.
+
+    If you don't pass any arguments, then by default it will instantiate
+    the JoblibParallelBackend:
+
+    ??? Example
+        ```python
+        parallel_backend = init_parallel_backend()
+        ```
+
+    To create a parallel backend instance with for example `ray` as a backend,
+    you can pass the backend name as a string:.
+
+    ??? Example
+        ```python
+        parallel_backend = init_parallel_backend(backend_name="ray")
+        ```
+
+
+    The following is an example of the deprecated
+    way for instantiating a parallel backend:
 
     ??? Example
         ``` python
@@ -112,26 +135,23 @@ def init_parallel_backend(config: ParallelConfig) -> ParallelBackend:
         parallel_backend = init_parallel_backend(config)
         ```
 
-    To create a parallel backend instance with a different backend, e.g. ray,
-    you can pass the backend name as a string to the constructor of
-    [ParallelConfig][pydvl.utils.config.ParallelConfig].
-
-    ??? Example
-        ```python
-        config = ParallelConfig(backend="ray")
-        parallel_backend = init_parallel_backend(config)
-        ```
-
     Args:
-        config: instance of [ParallelConfig][pydvl.utils.config.ParallelConfig]
+        backend_name: Name of the backend to instantiate.
+        config: (**DEPRECATED**) Object configuring parallel computation,
             with cluster address, number of cpus, etc.
 
 
     """
+    if backend_name is None:
+        if config is None:
+            backend_name = "joblib"
+        else:
+            backend_name = config.backend
+
     try:
-        parallel_backend_cls = ParallelBackend.BACKENDS[config.backend]
+        parallel_backend_cls = ParallelBackend.BACKENDS[backend_name]
     except KeyError:
-        raise NotImplementedError(f"Unexpected parallel backend {config.backend}")
+        raise NotImplementedError(f"Unexpected parallel backend {backend_name}")
     return parallel_backend_cls(config)  # type: ignore
 
 

--- a/src/pydvl/parallel/backend.py
+++ b/src/pydvl/parallel/backend.py
@@ -15,7 +15,7 @@ __all__ = [
     "init_parallel_backend",
     "effective_n_jobs",
     "available_cpus",
-    "BaseParallelBackend",
+    "ParallelBackend",
     "CancellationPolicy",
 ]
 
@@ -42,15 +42,15 @@ class CancellationPolicy(Flag):
     ALL = PENDING | RUNNING
 
 
-class BaseParallelBackend:
+class ParallelBackend:
     """Abstract base class for all parallel backends."""
 
     config: dict[str, Any] = {}
-    BACKENDS: dict[str, "Type[BaseParallelBackend]"] = {}
+    BACKENDS: dict[str, "Type[ParallelBackend]"] = {}
 
     def __init_subclass__(cls, *, backend_name: str, **kwargs):
         super().__init_subclass__(**kwargs)
-        BaseParallelBackend.BACKENDS[backend_name] = cls
+        ParallelBackend.BACKENDS[backend_name] = cls
 
     @classmethod
     @abstractmethod
@@ -98,7 +98,7 @@ class BaseParallelBackend:
     remove_in="0.10.0",
     deprecated_in="0.9.0",
 )
-def init_parallel_backend(config: ParallelConfig) -> BaseParallelBackend:
+def init_parallel_backend(config: ParallelConfig) -> ParallelBackend:
     """Initializes the parallel backend and returns an instance of it.
 
     The following example creates a parallel backend instance with the default
@@ -127,7 +127,7 @@ def init_parallel_backend(config: ParallelConfig) -> BaseParallelBackend:
 
     """
     try:
-        parallel_backend_cls = BaseParallelBackend.BACKENDS[config.backend]
+        parallel_backend_cls = ParallelBackend.BACKENDS[config.backend]
     except KeyError:
         raise NotImplementedError(f"Unexpected parallel backend {config.backend}")
     return parallel_backend_cls.create(config)  # type: ignore

--- a/src/pydvl/parallel/backends/joblib.py
+++ b/src/pydvl/parallel/backends/joblib.py
@@ -22,12 +22,9 @@ logger = logging.getLogger(__name__)
 class JoblibParallelBackend(BaseParallelBackend, backend_name="joblib"):
     """Class used to wrap joblib to make it transparent to algorithms.
 
-    It shouldn't be initialized directly. You should instead call
-    [init_parallel_backend()][pydvl.parallel.backend.init_parallel_backend].
-
     ??? Example
         ``` python
-        from pydvl.parallel import init_paralle_backend, ParallelConfig
+        from pydvl.parallel import init_parallel_backend, ParallelConfig
         config = ParallelConfig(backend="joblib")
         parallel_backend = init_parallel_backend(config)
         ```

--- a/src/pydvl/parallel/backends/joblib.py
+++ b/src/pydvl/parallel/backends/joblib.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import warnings
 from concurrent.futures import Executor
-from typing import Callable, Optional, TypeVar, Union, cast
+from typing import Callable, TypeVar, cast
 
 from deprecate import deprecated
 from joblib import delayed, effective_n_jobs
@@ -36,8 +36,8 @@ class JoblibParallelBackend(ParallelBackend, backend_name="joblib"):
         deprecated_in="0.9.0",
         remove_in="0.10.0",
     )
-    def __init__(self, config: Optional[ParallelConfig] = None) -> None:
-        n_jobs: Optional[int] = None
+    def __init__(self, config: ParallelConfig | None = None) -> None:
+        n_jobs: int | None = None
         if config is not None:
             n_jobs = config.n_cpus_local
         self.config = {
@@ -47,10 +47,10 @@ class JoblibParallelBackend(ParallelBackend, backend_name="joblib"):
     @classmethod
     def executor(
         cls,
-        max_workers: Optional[int] = None,
+        max_workers: int | None = None,
         *,
-        config: Optional[ParallelConfig] = None,
-        cancel_futures: Union[CancellationPolicy, bool] = CancellationPolicy.NONE,
+        config: ParallelConfig | None = None,
+        cancel_futures: CancellationPolicy | bool = CancellationPolicy.NONE,
     ) -> Executor:
         """Returns a futures executor for the parallel backend.
 

--- a/src/pydvl/parallel/backends/joblib.py
+++ b/src/pydvl/parallel/backends/joblib.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import logging
 import warnings
 from concurrent.futures import Executor
-from typing import Callable, TypeVar, cast
+from typing import Callable, Optional, TypeVar, cast
 
 import joblib
+from deprecate import deprecated
 from joblib import delayed
 from joblib.externals.loky import get_reusable_executor
 
@@ -24,28 +25,31 @@ class JoblibParallelBackend(BaseParallelBackend, backend_name="joblib"):
 
     ??? Example
         ``` python
-        from pydvl.parallel import init_parallel_backend, ParallelConfig
-        config = ParallelConfig(backend="joblib")
-        parallel_backend = init_parallel_backend(config)
+        from pydvl.parallel import JoblibParallelBackend
+        parallel_backend = JoblibParallelBackend()
         ```
 
     ??? Example
         ``` python
         import joblib
-        from pydvl.parallel import init_paralle_backend, ParallelConfig
+        from pydvl.parallel import JoblibParallelBackend
         with joblib.parallel_config(verbose=100):
-            config = ParallelConfig(backend="joblib")
-            parallel_backend = init_parallel_backend(config)
+            parallel_backend = JoblibParallelBackend()
         ```
-
-    Args:
-        config: instance of [ParallelConfig][pydvl.utils.config.ParallelConfig]
-            with cluster address, number of cpus, etc.
     """
 
-    def __init__(self, config: ParallelConfig):
+    @deprecated(
+        target=True,
+        args_mapping={"config": None},
+        deprecated_in="0.9.0",
+        remove_in="0.10.0",
+    )
+    def __init__(self, config: Optional[ParallelConfig] = None):
+        n_jobs: Optional[int] = None
+        if config is not None:
+            n_jobs = config.n_cpus_local
         self.config = {
-            "n_jobs": config.n_cpus_local,
+            "n_jobs": n_jobs,
         }
 
     @classmethod

--- a/src/pydvl/parallel/backends/joblib.py
+++ b/src/pydvl/parallel/backends/joblib.py
@@ -9,6 +9,7 @@ import joblib
 from deprecate import deprecated
 from joblib import delayed
 from joblib.externals.loky import get_reusable_executor
+from joblib.externals.loky.reusable_executor import _ReusablePoolExecutor
 
 from pydvl.parallel.backend import CancellationPolicy, ParallelBackend
 from pydvl.parallel.config import ParallelConfig
@@ -23,18 +24,10 @@ logger = logging.getLogger(__name__)
 class JoblibParallelBackend(ParallelBackend, backend_name="joblib"):
     """Class used to wrap joblib to make it transparent to algorithms.
 
-    ??? Example
+    !!! Example
         ``` python
         from pydvl.parallel import JoblibParallelBackend
         parallel_backend = JoblibParallelBackend()
-        ```
-
-    ??? Example
-        ``` python
-        import joblib
-        from pydvl.parallel import JoblibParallelBackend
-        with joblib.parallel_config(verbose=100):
-            parallel_backend = JoblibParallelBackend()
         ```
     """
 
@@ -60,6 +53,26 @@ class JoblibParallelBackend(ParallelBackend, backend_name="joblib"):
         config: Optional[ParallelConfig] = None,
         cancel_futures: Union[CancellationPolicy, bool] = CancellationPolicy.NONE,
     ) -> Executor:
+        """Returns a futures executor for the parallel backend.
+
+        !!! Example
+            ``` python
+            from pydvl.parallel import JoblibParallelBackend
+            parallel_backend = JoblibParallelBackend()
+            with parallel_backend.executor() as executor:
+                executor.submit(...)
+            ```
+
+        Args:
+            max_workers: Maximum number of parallel workers.
+            config: (**DEPRECATED**) Object configuring parallel computation,
+                with cluster address, number of cpus, etc.
+            cancel_futures: Policy to use when cancelling futures
+                after exiting an Executor.
+
+        Returns:
+            Instance of [_ReusablePoolExecutor][joblib.externals.loky.reusable_executor._ReusablePoolExecutor].
+        """
         if config is not None:
             warnings.warn(
                 "The `JoblibParallelBackend` uses deprecated arguments: "

--- a/src/pydvl/parallel/backends/joblib.py
+++ b/src/pydvl/parallel/backends/joblib.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import logging
 import warnings
 from concurrent.futures import Executor
-from typing import Callable, Optional, TypeVar, Union, cast
+from typing import Callable, Optional, TypeVar, Union
 
 import joblib
 from deprecate import deprecated
 from joblib import delayed
 from joblib.externals.loky import get_reusable_executor
-from joblib.externals.loky.reusable_executor import _ReusablePoolExecutor
 
 from pydvl.parallel.backend import CancellationPolicy, ParallelBackend
 from pydvl.parallel.config import ParallelConfig
@@ -85,7 +84,8 @@ class JoblibParallelBackend(ParallelBackend, backend_name="joblib"):
             warnings.warn(
                 "Cancellation of futures is not supported by the joblib backend",
             )
-        return cast(Executor, get_reusable_executor(max_workers=max_workers))
+        executor: Executor = get_reusable_executor(max_workers=max_workers)
+        return executor
 
     def get(self, v: T, *args, **kwargs) -> T:
         return v

--- a/src/pydvl/parallel/backends/joblib.py
+++ b/src/pydvl/parallel/backends/joblib.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import warnings
 from concurrent.futures import Executor
-from typing import Callable, Optional, TypeVar, Union
+from typing import Callable, Optional, TypeVar, Union, cast
 
 from deprecate import deprecated
 from joblib import delayed, effective_n_jobs
@@ -84,8 +84,7 @@ class JoblibParallelBackend(ParallelBackend, backend_name="joblib"):
             warnings.warn(
                 "Cancellation of futures is not supported by the joblib backend",
             )
-        executor: Executor = get_reusable_executor(max_workers=max_workers)
-        return executor
+        return cast(Executor, get_reusable_executor(max_workers=max_workers))
 
     def get(self, v: T, *args, **kwargs) -> T:
         return v

--- a/src/pydvl/parallel/backends/joblib.py
+++ b/src/pydvl/parallel/backends/joblib.py
@@ -75,7 +75,7 @@ class JoblibParallelBackend(ParallelBackend, backend_name="joblib"):
         if config is not None:
             warnings.warn(
                 "The `JoblibParallelBackend` uses deprecated arguments: "
-                "`config` -> `None`. They were deprecated since v0.9.0 "
+                "`config`. They were deprecated since v0.9.0 "
                 "and will be removed in v0.10.0.",
                 FutureWarning,
             )

--- a/src/pydvl/parallel/backends/joblib.py
+++ b/src/pydvl/parallel/backends/joblib.py
@@ -44,7 +44,7 @@ class JoblibParallelBackend(BaseParallelBackend, backend_name="joblib"):
         deprecated_in="0.9.0",
         remove_in="0.10.0",
     )
-    def __init__(self, config: Optional[ParallelConfig] = None):
+    def __init__(self, config: Optional[ParallelConfig] = None) -> None:
         n_jobs: Optional[int] = None
         if config is not None:
             n_jobs = config.n_cpus_local

--- a/src/pydvl/parallel/backends/joblib.py
+++ b/src/pydvl/parallel/backends/joblib.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import warnings
 from concurrent.futures import Executor
-from typing import Callable, Optional, TypeVar, cast
+from typing import Callable, Optional, TypeVar, Union, cast
 
 import joblib
 from deprecate import deprecated
@@ -55,13 +55,22 @@ class JoblibParallelBackend(ParallelBackend, backend_name="joblib"):
     @classmethod
     def executor(
         cls,
-        max_workers: int | None = None,
-        config: ParallelConfig = ParallelConfig(),
-        cancel_futures: CancellationPolicy = CancellationPolicy.NONE,
+        max_workers: Optional[int] = None,
+        *,
+        config: Optional[ParallelConfig] = None,
+        cancel_futures: Union[CancellationPolicy, bool] = CancellationPolicy.NONE,
     ) -> Executor:
+        if config is not None:
+            warnings.warn(
+                "The `JoblibParallelBackend` uses deprecated arguments: "
+                "`config` -> `None`. They were deprecated since v0.9.0 "
+                "and will be removed in v0.10.0.",
+                FutureWarning,
+            )
+
         if cancel_futures not in (CancellationPolicy.NONE, False):
             warnings.warn(
-                "Cancellation of futures is not supported by the joblib backend"
+                "Cancellation of futures is not supported by the joblib backend",
             )
         return cast(Executor, get_reusable_executor(max_workers=max_workers))
 

--- a/src/pydvl/parallel/backends/joblib.py
+++ b/src/pydvl/parallel/backends/joblib.py
@@ -10,7 +10,7 @@ from deprecate import deprecated
 from joblib import delayed
 from joblib.externals.loky import get_reusable_executor
 
-from pydvl.parallel.backend import BaseParallelBackend, CancellationPolicy
+from pydvl.parallel.backend import CancellationPolicy, ParallelBackend
 from pydvl.parallel.config import ParallelConfig
 
 __all__ = ["JoblibParallelBackend"]
@@ -20,7 +20,7 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 
-class JoblibParallelBackend(BaseParallelBackend, backend_name="joblib"):
+class JoblibParallelBackend(ParallelBackend, backend_name="joblib"):
     """Class used to wrap joblib to make it transparent to algorithms.
 
     ??? Example

--- a/src/pydvl/parallel/backends/joblib.py
+++ b/src/pydvl/parallel/backends/joblib.py
@@ -30,6 +30,9 @@ class JoblibParallelBackend(ParallelBackend, backend_name="joblib"):
         ```
     """
 
+    _joblib_backend_name: str = "loky"
+    """Name of the backend to use for joblib inside [MapReduceJob][pydvl.parallel.mapreduce.MapReduceJob]."""
+
     @deprecated(
         target=True,
         args_mapping={"config": None},

--- a/src/pydvl/parallel/backends/ray.py
+++ b/src/pydvl/parallel/backends/ray.py
@@ -82,7 +82,7 @@ class RayParallelBackend(ParallelBackend, backend_name="ray"):
         if config is not None:
             warnings.warn(
                 "The `RayParallelBackend` uses deprecated arguments: "
-                "`config` -> `None`. They were deprecated since v0.9.0 "
+                "`config`. They were deprecated since v0.9.0 "
                 "and will be removed in v0.10.0.",
                 FutureWarning,
             )

--- a/src/pydvl/parallel/backends/ray.py
+++ b/src/pydvl/parallel/backends/ray.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from concurrent.futures import Executor
 from typing import Any, Callable, Iterable, Optional, TypeVar
 
@@ -49,12 +50,20 @@ class RayParallelBackend(BaseParallelBackend, backend_name="ray"):
     def executor(
         cls,
         max_workers: int | None = None,
-        config: ParallelConfig = ParallelConfig(),
+        config: Optional[ParallelConfig] = None,
         cancel_futures: CancellationPolicy = CancellationPolicy.PENDING,
     ) -> Executor:
         from pydvl.parallel.futures.ray import RayExecutor
 
-        return RayExecutor(max_workers, config=config, cancel_futures=cancel_futures)  # type: ignore
+        if config is not None:
+            warnings.warn(
+                "The `RayParallelBackend` uses deprecated arguments: "
+                "`config` -> `None`. They were deprecated since v0.9.0 "
+                "and will be removed in v0.10.0.",
+                FutureWarning,
+            )
+
+        return RayExecutor(max_workers, cancel_futures=cancel_futures)  # type: ignore
 
     def get(self, v: ObjectRef | Iterable[ObjectRef] | T, *args, **kwargs) -> T | Any:
         timeout: float | None = kwargs.get("timeout", None)

--- a/src/pydvl/parallel/backends/ray.py
+++ b/src/pydvl/parallel/backends/ray.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from concurrent.futures import Executor
-from typing import Any, Callable, Iterable, Optional, TypeVar
+from typing import Any, Callable, Iterable, Optional, TypeVar, Union
 
 import ray
 from deprecate import deprecated
@@ -50,8 +50,9 @@ class RayParallelBackend(ParallelBackend, backend_name="ray"):
     def executor(
         cls,
         max_workers: int | None = None,
+        *,
         config: Optional[ParallelConfig] = None,
-        cancel_futures: CancellationPolicy = CancellationPolicy.PENDING,
+        cancel_futures: Union[CancellationPolicy, bool] = CancellationPolicy.PENDING,
     ) -> Executor:
         from pydvl.parallel.futures.ray import RayExecutor
 

--- a/src/pydvl/parallel/backends/ray.py
+++ b/src/pydvl/parallel/backends/ray.py
@@ -20,9 +20,6 @@ T = TypeVar("T")
 class RayParallelBackend(BaseParallelBackend, backend_name="ray"):
     """Class used to wrap ray to make it transparent to algorithms.
 
-    It shouldn't be initialized directly. You should instead call
-    [init_parallel_backend()][pydvl.parallel.backend.init_parallel_backend].
-
     ??? Example
         ``` python
         import ray

--- a/src/pydvl/parallel/backends/ray.py
+++ b/src/pydvl/parallel/backends/ray.py
@@ -9,7 +9,7 @@ from deprecate import deprecated
 from ray import ObjectRef
 from ray.util.joblib import register_ray
 
-from pydvl.parallel.backend import BaseParallelBackend, CancellationPolicy
+from pydvl.parallel.backend import CancellationPolicy, ParallelBackend
 from pydvl.parallel.config import ParallelConfig
 
 __all__ = ["RayParallelBackend"]
@@ -18,7 +18,7 @@ __all__ = ["RayParallelBackend"]
 T = TypeVar("T")
 
 
-class RayParallelBackend(BaseParallelBackend, backend_name="ray"):
+class RayParallelBackend(ParallelBackend, backend_name="ray"):
     """Class used to wrap ray to make it transparent to algorithms.
 
     ??? Example

--- a/src/pydvl/parallel/backends/ray.py
+++ b/src/pydvl/parallel/backends/ray.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from concurrent.futures import Executor
-from typing import Any, Callable, Iterable, Optional, TypeVar, Union
+from typing import Any, Callable, Iterable, TypeVar
 
 import ray
 from deprecate import deprecated
@@ -36,7 +36,7 @@ class RayParallelBackend(ParallelBackend, backend_name="ray"):
         deprecated_in="0.9.0",
         remove_in="0.10.0",
     )
-    def __init__(self, config: Optional[ParallelConfig] = None) -> None:
+    def __init__(self, config: ParallelConfig | None = None) -> None:
         if not ray.is_initialized():
             raise RuntimeError(
                 "Starting from v0.9.0, ray is no longer automatically initialized. "
@@ -51,8 +51,8 @@ class RayParallelBackend(ParallelBackend, backend_name="ray"):
         cls,
         max_workers: int | None = None,
         *,
-        config: Optional[ParallelConfig] = None,
-        cancel_futures: Union[CancellationPolicy, bool] = CancellationPolicy.PENDING,
+        config: ParallelConfig | None = None,
+        cancel_futures: CancellationPolicy | bool = CancellationPolicy.PENDING,
     ) -> Executor:
         """Returns a futures executor for the parallel backend.
 

--- a/src/pydvl/parallel/backends/ray.py
+++ b/src/pydvl/parallel/backends/ray.py
@@ -30,6 +30,9 @@ class RayParallelBackend(ParallelBackend, backend_name="ray"):
         ```
     """
 
+    _joblib_backend_name: str = "ray"
+    """Name of the backend to use for joblib inside [MapReduceJob][pydvl.parallel.mapreduce.MapReduceJob]."""
+
     @deprecated(
         target=True,
         args_mapping={"config": None},

--- a/src/pydvl/parallel/backends/ray.py
+++ b/src/pydvl/parallel/backends/ray.py
@@ -21,7 +21,7 @@ T = TypeVar("T")
 class RayParallelBackend(ParallelBackend, backend_name="ray"):
     """Class used to wrap ray to make it transparent to algorithms.
 
-    ??? Example
+    !!! Example
         ``` python
         import ray
         from pydvl.parallel import RayParallelBackend
@@ -54,6 +54,29 @@ class RayParallelBackend(ParallelBackend, backend_name="ray"):
         config: Optional[ParallelConfig] = None,
         cancel_futures: Union[CancellationPolicy, bool] = CancellationPolicy.PENDING,
     ) -> Executor:
+        """Returns a futures executor for the parallel backend.
+
+        !!! Example
+            ``` python
+            import ray
+            from pydvl.parallel import RayParallelBackend
+            ray.init()
+            parallel_backend = RayParallelBackend()
+            with parallel_backend.executor() as executor:
+                executor.submit(...)
+            ```
+
+        Args:
+            max_workers: Maximum number of parallel workers.
+            config: (**DEPRECATED**) Object configuring parallel computation,
+                with cluster address, number of cpus, etc.
+            cancel_futures: Policy to use when cancelling futures
+                after exiting an Executor.
+
+        Returns:
+            Instance of [RayExecutor][pydvl.parallel.futures.ray.RayExecutor].
+        """
+        # Imported here to avoid circular import errors
         from pydvl.parallel.futures.ray import RayExecutor
 
         if config is not None:

--- a/src/pydvl/parallel/backends/ray.py
+++ b/src/pydvl/parallel/backends/ray.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import logging
 from concurrent.futures import Executor
-from typing import Any, Callable, Iterable, TypeVar
+from typing import Any, Callable, Iterable, Optional, TypeVar
 
 import ray
+from deprecate import deprecated
 from ray import ObjectRef
 from ray.util.joblib import register_ray
 
@@ -23,18 +23,19 @@ class RayParallelBackend(BaseParallelBackend, backend_name="ray"):
     ??? Example
         ``` python
         import ray
-        from pydvl.parallel import init_parallel_backend, ParallelConfig
+        from pydvl.parallel import RayParallelBackend
         ray.init()
-        config = ParallelConfig(backend="ray")
-        parallel_backend = init_parallel_backend(config)
+        parallel_backend = RayParallelBackend()
         ```
-
-    Args:
-        config: instance of [ParallelConfig][pydvl.utils.config.ParallelConfig]
-            with cluster address, number of cpus, etc.
     """
 
-    def __init__(self, config: ParallelConfig):
+    @deprecated(
+        target=True,
+        args_mapping={"config": None},
+        deprecated_in="0.9.0",
+        remove_in="0.10.0",
+    )
+    def __init__(self, config: Optional[ParallelConfig] = None) -> None:
         if not ray.is_initialized():
             raise RuntimeError(
                 "Starting from v0.9.0, ray is no longer automatically initialized. "

--- a/src/pydvl/parallel/futures/__init__.py
+++ b/src/pydvl/parallel/futures/__init__.py
@@ -2,13 +2,23 @@ from concurrent.futures import Executor
 from contextlib import contextmanager
 from typing import Generator, Optional
 
+from deprecate import deprecated
+
 from pydvl.parallel.backend import ParallelBackend
 from pydvl.parallel.config import ParallelConfig
 
 __all__ = ["init_executor"]
 
 
+# TODO: delete this function once it's made redundant in v0.10.0
+# This string for the benefit of deprecation searches:
+# remove_in="0.10.0"
 @contextmanager
+@deprecated(
+    target=None,
+    deprecated_in="0.9.0",
+    remove_in="0.10.0",
+)
 def init_executor(
     max_workers: Optional[int] = None,
     config: ParallelConfig = ParallelConfig(),

--- a/src/pydvl/parallel/futures/__init__.py
+++ b/src/pydvl/parallel/futures/__init__.py
@@ -2,7 +2,7 @@ from concurrent.futures import Executor
 from contextlib import contextmanager
 from typing import Generator, Optional
 
-from pydvl.parallel.backend import BaseParallelBackend
+from pydvl.parallel.backend import ParallelBackend
 from pydvl.parallel.config import ParallelConfig
 
 __all__ = ["init_executor"]
@@ -41,7 +41,7 @@ def init_executor(
         ```
     """
     try:
-        cls = BaseParallelBackend.BACKENDS[config.backend]
+        cls = ParallelBackend.BACKENDS[config.backend]
         with cls.executor(max_workers=max_workers, config=config, **kwargs) as e:
             yield e
     except KeyError:

--- a/src/pydvl/parallel/futures/__init__.py
+++ b/src/pydvl/parallel/futures/__init__.py
@@ -5,11 +5,6 @@ from typing import Generator, Optional
 from pydvl.parallel.backend import BaseParallelBackend
 from pydvl.parallel.config import ParallelConfig
 
-try:
-    from pydvl.parallel.futures.ray import RayExecutor
-except ModuleNotFoundError:
-    pass
-
 __all__ = ["init_executor"]
 
 

--- a/src/pydvl/parallel/futures/ray.py
+++ b/src/pydvl/parallel/futures/ray.py
@@ -5,7 +5,7 @@ import threading
 import time
 import types
 from concurrent.futures import Executor, Future
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar, Union
 from weakref import WeakSet, ref
 
 from deprecate import deprecated
@@ -57,7 +57,7 @@ class RayExecutor(Executor):
         max_workers: Optional[int] = None,
         *,
         config: Optional[ParallelConfig] = None,
-        cancel_futures: CancellationPolicy = CancellationPolicy.ALL,
+        cancel_futures: Union[CancellationPolicy, bool] = CancellationPolicy.ALL,
     ):
         if max_workers is not None:
             if max_workers <= 0:

--- a/src/pydvl/parallel/map_reduce.py
+++ b/src/pydvl/parallel/map_reduce.py
@@ -99,6 +99,7 @@ class MapReduceJob(Generic[T, R]):
 
         self.timeout = timeout
 
+        self._n_jobs = -1
         # This uses the setter defined below
         self.n_jobs = n_jobs
 

--- a/src/pydvl/parallel/map_reduce.py
+++ b/src/pydvl/parallel/map_reduce.py
@@ -149,7 +149,7 @@ class MapReduceJob(Generic[T, R]):
                 f"Unexpected parallel backend {self.parallel_backend.__class__.__name__}"
             )
 
-        with Parallel(prefer=backend) as parallel:
+        with Parallel(backend=backend, prefer="processes") as parallel:
             chunks = self._chunkify(self.inputs_, n_chunks=self.n_jobs)
             map_results: List[R] = parallel(
                 delayed(self._map_func)(

--- a/src/pydvl/utils/types.py
+++ b/src/pydvl/utils/types.py
@@ -16,7 +16,6 @@ __all__ = [
     "IndexT",
     "NameT",
     "MapFunction",
-    "NoPublicConstructor",
     "ReduceFunction",
     "Seed",
     "SupervisedModel",
@@ -82,32 +81,6 @@ class SupervisedModel(Protocol):
             The score of the model on `(x, y)`
         """
         pass
-
-
-class NoPublicConstructor(ABCMeta):
-    """Metaclass that ensures a private constructor
-
-    If a class uses this metaclass like this:
-
-        class SomeClass(metaclass=NoPublicConstructor):
-            pass
-
-    If you try to instantiate your class (`SomeClass()`),
-    a `TypeError` will be thrown.
-
-    Taken almost verbatim from:
-    [https://stackoverflow.com/a/64682734](https://stackoverflow.com/a/64682734)
-    """
-
-    def __call__(cls, *args, **kwargs):
-        raise TypeError(
-            f"{cls.__module__}.{cls.__qualname__} cannot be initialized directly. "
-            "Use the proper factory instead."
-        )
-
-    def create(cls, *args: Any, **kwargs: Any):
-        """Create an instance of the class"""
-        return super().__call__(*args, **kwargs)
 
 
 def ensure_seed_sequence(

--- a/src/pydvl/value/least_core/__init__.py
+++ b/src/pydvl/value/least_core/__init__.py
@@ -87,7 +87,7 @@ def compute_least_core_values(
         progress = False
         if n_iterations is None:
             raise ValueError("n_iterations cannot be None for Monte Carlo Least Core")
-        return montecarlo_least_core(
+        return montecarlo_least_core(  # type: ignore
             u=u,
             n_iterations=n_iterations,
             n_jobs=n_jobs,

--- a/src/pydvl/value/least_core/montecarlo.py
+++ b/src/pydvl/value/least_core/montecarlo.py
@@ -12,7 +12,6 @@ from pydvl.parallel import (
     ParallelBackend,
     ParallelConfig,
     _maybe_init_parallel_backend,
-    effective_n_jobs,
 )
 from pydvl.utils.numeric import random_powerset
 from pydvl.utils.types import Seed
@@ -154,9 +153,11 @@ def mclc_prepare_problem(
         )
         n_iterations = 2**n
 
-    iterations_per_job = max(1, n_iterations // effective_n_jobs(n_jobs, config))
-
     parallel_backend = _maybe_init_parallel_backend(parallel_backend, config)
+
+    iterations_per_job = max(
+        1, n_iterations // parallel_backend.effective_n_jobs(n_jobs)
+    )
 
     map_reduce_job: MapReduceJob["Utility", "LeastCoreProblem"] = MapReduceJob(
         inputs=u,

--- a/src/pydvl/value/least_core/montecarlo.py
+++ b/src/pydvl/value/least_core/montecarlo.py
@@ -83,6 +83,11 @@ def montecarlo_least_core(
 
     Returns:
         Object with the data values and the least core value.
+
+    !!! tip "Changed in version 0.9.0"
+        Deprecated `config` argument and added a `parallel_backend`
+        argument to allow users to pass the Parallel Backend instance
+        directly.
     """
     problem = mclc_prepare_problem(
         u,
@@ -102,6 +107,12 @@ def montecarlo_least_core(
     )
 
 
+@deprecated(
+    target=True,
+    args_mapping={"config": "config"},
+    deprecated_in="0.9.0",
+    remove_in="0.10.0",
+)
 def mclc_prepare_problem(
     u: Utility,
     n_iterations: int,
@@ -120,6 +131,11 @@ def mclc_prepare_problem(
     See
     [montecarlo_least_core][pydvl.value.least_core.montecarlo.montecarlo_least_core]
     for argument descriptions.
+
+    !!! note "Changed in version 0.9.0"
+        Deprecated `config` argument and added a `parallel_backend`
+        argument to allow users to pass the Parallel Backend instance
+        directly.
     """
     n = len(u.data)
 

--- a/src/pydvl/value/least_core/montecarlo.py
+++ b/src/pydvl/value/least_core/montecarlo.py
@@ -3,10 +3,17 @@ import warnings
 from typing import Iterable, Optional
 
 import numpy as np
+from deprecate import deprecated
 from numpy.typing import NDArray
 from tqdm.auto import tqdm
 
-from pydvl.parallel import MapReduceJob, ParallelConfig, effective_n_jobs
+from pydvl.parallel import (
+    MapReduceJob,
+    ParallelBackend,
+    ParallelConfig,
+    _maybe_init_parallel_backend,
+    effective_n_jobs,
+)
 from pydvl.utils.numeric import random_powerset
 from pydvl.utils.types import Seed
 from pydvl.utils.utility import Utility
@@ -19,12 +26,19 @@ logger = logging.getLogger(__name__)
 __all__ = ["montecarlo_least_core", "mclc_prepare_problem"]
 
 
+@deprecated(
+    target=True,
+    args_mapping={"config": "config"},
+    deprecated_in="0.9.0",
+    remove_in="0.10.0",
+)
 def montecarlo_least_core(
     u: Utility,
     n_iterations: int,
     *,
     n_jobs: int = 1,
-    config: ParallelConfig = ParallelConfig(),
+    parallel_backend: Optional[ParallelBackend] = None,
+    config: Optional[ParallelConfig] = None,
     non_negative_subsidy: bool = False,
     solver_options: Optional[dict] = None,
     progress: bool = False,
@@ -51,8 +65,13 @@ def montecarlo_least_core(
         u: Utility object with model, data, and scoring function
         n_iterations: total number of iterations to use
         n_jobs: number of jobs across which to distribute the computation
-        config: Object configuring parallel computation, with cluster
-            address, number of cpus, etc.
+        parallel_backend: Parallel backend instance to use
+            for parallelizing computations. If `None`,
+            use [JoblibParallelBackend][pydvl.parallel.backends.JoblibParallelBackend] backend.
+            See the [Parallel Backends][pydvl.parallel.backends] package
+            for available options.
+        config: (**DEPRECATED**) Object configuring parallel computation,
+            with cluster address, number of cpus, etc.
         non_negative_subsidy: If True, the least core subsidy $e$ is constrained
             to be non-negative.
         solver_options: Dictionary of options that will be used to select a solver
@@ -66,7 +85,13 @@ def montecarlo_least_core(
         Object with the data values and the least core value.
     """
     problem = mclc_prepare_problem(
-        u, n_iterations, n_jobs=n_jobs, config=config, progress=progress, seed=seed
+        u,
+        n_iterations,
+        n_jobs=n_jobs,
+        parallel_backend=parallel_backend,
+        config=config,
+        progress=progress,
+        seed=seed,
     )
     return lc_solve_problem(
         problem,
@@ -82,7 +107,8 @@ def mclc_prepare_problem(
     n_iterations: int,
     *,
     n_jobs: int = 1,
-    config: ParallelConfig = ParallelConfig(),
+    parallel_backend: Optional[ParallelBackend] = None,
+    config: Optional[ParallelConfig] = None,
     progress: bool = False,
     seed: Optional[Seed] = None,
 ) -> LeastCoreProblem:
@@ -114,13 +140,15 @@ def mclc_prepare_problem(
 
     iterations_per_job = max(1, n_iterations // effective_n_jobs(n_jobs, config))
 
+    parallel_backend = _maybe_init_parallel_backend(parallel_backend, config)
+
     map_reduce_job: MapReduceJob["Utility", "LeastCoreProblem"] = MapReduceJob(
         inputs=u,
         map_func=_montecarlo_least_core,
         reduce_func=_reduce_func,
         map_kwargs=dict(n_iterations=iterations_per_job, progress=progress),
         n_jobs=n_jobs,
-        config=config,
+        parallel_backend=parallel_backend,
     )
 
     return map_reduce_job(seed=seed)

--- a/src/pydvl/value/loo/loo.py
+++ b/src/pydvl/value/loo/loo.py
@@ -6,7 +6,7 @@ from typing import Optional
 from deprecate import deprecated
 from tqdm import tqdm
 
-from pydvl.parallel import ParallelBackend, ParallelConfig, maybe_init_parallel_backend
+from pydvl.parallel import ParallelBackend, ParallelConfig, _maybe_init_parallel_backend
 from pydvl.utils import Utility
 from pydvl.value.result import ValuationResult
 
@@ -69,7 +69,7 @@ def compute_loo(
     def fun(idx: int) -> tuple[int, float]:
         return idx, total_utility - u(all_indices.difference({idx}))
 
-    parallel_backend = maybe_init_parallel_backend(parallel_backend, config)
+    parallel_backend = _maybe_init_parallel_backend(parallel_backend, config)
     max_workers = parallel_backend.effective_n_jobs(n_jobs)
     n_submitted_jobs = 2 * max_workers  # number of jobs in the queue
 

--- a/src/pydvl/value/loo/loo.py
+++ b/src/pydvl/value/loo/loo.py
@@ -50,9 +50,10 @@ def compute_loo(
     !!! tip "New in version 0.7.0"
         Renamed from `naive_loo` and added parallel computation.
 
-    !!! note "Changed in version 0.9.0"
+    !!! tip "Changed in version 0.9.0"
         Deprecated `config` argument and added a `parallel_backend`
-        argument to allow users to pass the Parallel Backend configuration.
+        argument to allow users to pass the Parallel Backend instance
+        directly.
     """
     if len(u.data) < 3:
         raise ValueError("Dataset must have at least 2 elements")

--- a/src/pydvl/value/loo/loo.py
+++ b/src/pydvl/value/loo/loo.py
@@ -15,7 +15,7 @@ __all__ = ["compute_loo"]
 
 @deprecated(
     target=True,
-    args_mapping={"config": None},
+    args_mapping={"config": "config"},
     deprecated_in="0.9.0",
     remove_in="0.10.0",
 )

--- a/src/pydvl/value/loo/loo.py
+++ b/src/pydvl/value/loo/loo.py
@@ -36,10 +36,11 @@ def compute_loo(
         progress: If True, display a progress bar
         n_jobs: Number of parallel jobs to use
         parallel_backend: Parallel backend instance to use
-            for parallelizing computations. If None, use joblib backend.
+            for parallelizing computations. If `None`,
+            use [JoblibParallelBackend][pydvl.parallel.backends.JoblibParallelBackend] backend.
             See the [Parallel Backends][pydvl.parallel.backends] package
             for available options.
-        config: (Deprecated) Object configuring parallel computation,
+        config: (**DEPRECATED**) Object configuring parallel computation,
             with cluster address, number of cpus, etc.
         progress: If True, display a progress bar
 

--- a/src/pydvl/value/shapley/classwise.py
+++ b/src/pydvl/value/shapley/classwise.py
@@ -397,7 +397,6 @@ def _permutation_montecarlo_classwise_shapley_one_step(
     """Helper function for [compute_classwise_shapley_values()]
     [pydvl.value.shapley.classwise.compute_classwise_shapley_values].
 
-
     Args:
         u: Utility object containing model, data, and scoring function. The
             scorer must be of type [ClasswiseScorer]
@@ -417,6 +416,10 @@ def _permutation_montecarlo_classwise_shapley_one_step(
 
     Returns:
         ValuationResult object containing computed data values.
+
+    !!! tip "Changed in version 0.9.0"
+        Deprecated `config` argument and added a `parallel_backend`
+        argument to allow users to pass the Parallel Backend configuration.
     """
     if done_sample_complements is None:
         done_sample_complements = MaxChecks(1)

--- a/src/pydvl/value/shapley/classwise.py
+++ b/src/pydvl/value/shapley/classwise.py
@@ -64,12 +64,15 @@ from copy import copy
 from typing import Callable, Optional, Set, Tuple, Union, cast
 
 import numpy as np
+from deprecate import deprecated
 from numpy.random import SeedSequence
 from numpy.typing import NDArray
 from tqdm import tqdm
 
 from pydvl.parallel import (
+    ParallelBackend,
     ParallelConfig,
+    _maybe_init_parallel_backend,
     effective_n_jobs,
     init_executor,
     init_parallel_backend,
@@ -238,6 +241,12 @@ class ClasswiseScorer(Scorer):
         return in_class_score, out_of_class_score
 
 
+@deprecated(
+    target=True,
+    args_mapping={"config": "config"},
+    deprecated_in="0.9.0",
+    remove_in="0.10.0",
+)
 def compute_classwise_shapley_values(
     u: Utility,
     *,
@@ -248,7 +257,8 @@ def compute_classwise_shapley_values(
     use_default_scorer_value: bool = True,
     min_elements_per_label: int = 1,
     n_jobs: int = 1,
-    config: ParallelConfig = ParallelConfig(),
+    parallel_backend: Optional[ParallelBackend] = None,
+    config: Optional[ParallelConfig] = None,
     progress: bool = False,
     seed: Optional[Seed] = None,
 ) -> ValuationResult:
@@ -288,7 +298,13 @@ def compute_classwise_shapley_values(
         min_elements_per_label: The minimum number of elements for each opposite
             label.
         n_jobs: Number of parallel jobs to run.
-        config: Parallel configuration.
+        parallel_backend: Parallel backend instance to use
+            for parallelizing computations. If `None`,
+            use [JoblibParallelBackend][pydvl.parallel.backends.JoblibParallelBackend] backend.
+            See the [Parallel Backends][pydvl.parallel.backends] package
+            for available options.
+        config: (**DEPRECATED**) Object configuring parallel computation,
+            with cluster address, number of cpus, etc.
         progress: Whether to display a progress bar.
         seed: Either an instance of a numpy random number generator or a seed for it.
 
@@ -327,7 +343,9 @@ def compute_classwise_shapley_values(
     terminate_exec = False
     seed_sequence = ensure_seed_sequence(seed)
 
-    with init_executor(max_workers=n_jobs, config=config) as executor:
+    parallel_backend = _maybe_init_parallel_backend(parallel_backend, config)
+
+    with parallel_backend.executor(max_workers=n_jobs) as executor:
         pending: Set[Future] = set()
         while True:
             completed_futures, pending = wait(

--- a/src/pydvl/value/shapley/classwise.py
+++ b/src/pydvl/value/shapley/classwise.py
@@ -69,14 +69,7 @@ from numpy.random import SeedSequence
 from numpy.typing import NDArray
 from tqdm import tqdm
 
-from pydvl.parallel import (
-    ParallelBackend,
-    ParallelConfig,
-    _maybe_init_parallel_backend,
-    effective_n_jobs,
-    init_executor,
-    init_parallel_backend,
-)
+from pydvl.parallel import ParallelBackend, ParallelConfig, _maybe_init_parallel_backend
 from pydvl.utils import (
     Dataset,
     Scorer,
@@ -330,9 +323,9 @@ def compute_classwise_shapley_values(
             " utility. See scoring argument of Utility."
         )
 
-    parallel_backend = init_parallel_backend(config)
+    parallel_backend = _maybe_init_parallel_backend(parallel_backend, config)
     u_ref = parallel_backend.put(u)
-    n_jobs = effective_n_jobs(n_jobs, config)
+    n_jobs = parallel_backend.effective_n_jobs(n_jobs)
     n_submitted_jobs = 2 * n_jobs
 
     pbar = tqdm(disable=not progress, position=0, total=100, unit="%")

--- a/src/pydvl/value/shapley/common.py
+++ b/src/pydvl/value/shapley/common.py
@@ -119,11 +119,11 @@ def compute_shapley_values(
             **kwargs,
         )
     elif mode == ShapleyMode.CombinatorialMontecarlo:
-        return combinatorial_montecarlo_shapley(
+        return combinatorial_montecarlo_shapley(  # type: ignore
             u, done=done, n_jobs=n_jobs, seed=seed, progress=progress
         )
     elif mode == ShapleyMode.CombinatorialExact:
-        return combinatorial_exact_shapley(u, n_jobs=n_jobs, progress=progress)
+        return combinatorial_exact_shapley(u, n_jobs=n_jobs, progress=progress)  # type: ignore
     elif mode == ShapleyMode.PermutationExact:
         return permutation_exact_shapley(u, progress=progress)
     elif mode == ShapleyMode.Owen or mode == ShapleyMode.OwenAntithetic:
@@ -137,7 +137,7 @@ def compute_shapley_values(
             if mode == ShapleyMode.Owen
             else OwenAlgorithm.Antithetic
         )
-        return owen_sampling_shapley(
+        return owen_sampling_shapley(  # type: ignore
             u,
             n_samples=int(kwargs.get("n_samples", -1)),
             max_q=int(kwargs.get("max_q", -1)),
@@ -155,7 +155,7 @@ def compute_shapley_values(
         if epsilon is None:
             raise ValueError("Group Testing requires error bound epsilon")
         delta = kwargs.pop("delta", 0.05)
-        return group_testing_shapley(
+        return group_testing_shapley(  # type: ignore
             u,
             epsilon=float(epsilon),
             delta=delta,

--- a/src/pydvl/value/shapley/gt.py
+++ b/src/pydvl/value/shapley/gt.py
@@ -237,6 +237,11 @@ def group_testing_shapley(
     !!! tip "Changed in version 0.5.0"
         Changed the solver to cvxpy instead of scipy's linprog. Added the ability
         to pass arbitrary options to it.
+
+    !!! tip "Changed in version 0.9.0"
+        Deprecated `config` argument and added a `parallel_backend`
+        argument to allow users to pass the Parallel Backend instance
+        directly.
     """
 
     n = len(u.data.indices)

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -50,6 +50,7 @@ from functools import reduce
 from typing import Optional, Sequence, Union
 
 import numpy as np
+from deprecate import deprecated
 from numpy.random import SeedSequence
 from numpy.typing import NDArray
 from tqdm.auto import tqdm
@@ -57,7 +58,9 @@ from tqdm.auto import tqdm
 from pydvl.parallel import (
     CancellationPolicy,
     MapReduceJob,
+    ParallelBackend,
     ParallelConfig,
+    _maybe_init_parallel_backend,
     effective_n_jobs,
     init_executor,
     init_parallel_backend,
@@ -127,13 +130,20 @@ def _permutation_montecarlo_one_step(
     return result
 
 
+@deprecated(
+    target=True,
+    args_mapping={"config": "config"},
+    deprecated_in="0.9.0",
+    remove_in="0.10.0",
+)
 def permutation_montecarlo_shapley(
     u: Utility,
     done: StoppingCriterion,
     *,
     truncation: TruncationPolicy = NoTruncation(),
     n_jobs: int = 1,
-    config: ParallelConfig = ParallelConfig(),
+    parallel_backend: Optional[ParallelBackend] = None,
+    config: Optional[ParallelConfig] = None,
     progress: bool = False,
     seed: Optional[Seed] = None,
 ) -> ValuationResult:
@@ -179,8 +189,13 @@ def permutation_montecarlo_shapley(
             processing a permutation and set all subsequent marginals to
             zero. Typically used to stop computation when the marginal is small.
         n_jobs: number of jobs across which to distribute the computation.
-        config: Object configuring parallel computation, with cluster address,
-            number of cpus, etc.
+        parallel_backend: Parallel backend instance to use
+            for parallelizing computations. If `None`,
+            use [JoblibParallelBackend][pydvl.parallel.backends.JoblibParallelBackend] backend.
+            See the [Parallel Backends][pydvl.parallel.backends] package
+            for available options.
+        config: (**DEPRECATED**) Object configuring parallel computation,
+            with cluster address, number of cpus, etc.
         progress: Whether to display a progress bar.
         seed: Either an instance of a numpy random number generator or a seed for it.
 
@@ -189,7 +204,7 @@ def permutation_montecarlo_shapley(
     """
     algorithm = "permutation_montecarlo_shapley"
 
-    parallel_backend = init_parallel_backend(config)
+    parallel_backend = _maybe_init_parallel_backend(parallel_backend, config)
     u = parallel_backend.put(u)
     max_workers = effective_n_jobs(n_jobs, config)
     n_submitted_jobs = 2 * max_workers  # number of jobs in the executor's queue
@@ -201,8 +216,8 @@ def permutation_montecarlo_shapley(
 
     pbar = tqdm(disable=not progress, total=100, unit="%")
 
-    with init_executor(
-        max_workers=max_workers, config=config, cancel_futures=CancellationPolicy.ALL
+    with parallel_backend.executor(
+        max_workers=max_workers, cancel_futures=CancellationPolicy.ALL
     ) as executor:
         pending: set[Future] = set()
         while True:
@@ -288,12 +303,19 @@ def _combinatorial_montecarlo_shapley(
     return result
 
 
+@deprecated(
+    target=True,
+    args_mapping={"config": "config"},
+    deprecated_in="0.9.0",
+    remove_in="0.10.0",
+)
 def combinatorial_montecarlo_shapley(
     u: Utility,
     done: StoppingCriterion,
     *,
     n_jobs: int = 1,
-    config: ParallelConfig = ParallelConfig(),
+    parallel_backend: Optional[ParallelBackend] = None,
+    config: Optional[ParallelConfig] = None,
     progress: bool = False,
     seed: Optional[Seed] = None,
 ) -> ValuationResult:
@@ -321,14 +343,20 @@ def combinatorial_montecarlo_shapley(
         n_jobs: number of parallel jobs across which to distribute the
             computation. Each worker receives a chunk of
             [indices][pydvl.utils.dataset.Dataset.indices]
-        config: Object configuring parallel computation, with cluster address,
-            number of cpus, etc.
+        parallel_backend: Parallel backend instance to use
+            for parallelizing computations. If `None`,
+            use [JoblibParallelBackend][pydvl.parallel.backends.JoblibParallelBackend] backend.
+            See the [Parallel Backends][pydvl.parallel.backends] package
+            for available options.
+        config: (**DEPRECATED**) Object configuring parallel computation,
+            with cluster address, number of cpus, etc.
         progress: Whether to display progress bars for each job.
         seed: Either an instance of a numpy random number generator or a seed for it.
 
     Returns:
         Object with the data values.
     """
+    parallel_backend = _maybe_init_parallel_backend(parallel_backend, config)
 
     map_reduce_job: MapReduceJob[NDArray, ValuationResult] = MapReduceJob(
         u.data.indices,
@@ -336,6 +364,6 @@ def combinatorial_montecarlo_shapley(
         reduce_func=lambda results: reduce(operator.add, results),
         map_kwargs=dict(u=u, done=done, progress=progress),
         n_jobs=n_jobs,
-        config=config,
+        parallel_backend=parallel_backend,
     )
     return map_reduce_job(seed=seed)

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -226,9 +226,7 @@ def permutation_montecarlo_shapley(
             pbar.n = 100 * done.completion()
             pbar.refresh()
 
-            completed, pending = wait(
-                pending, timeout=config.wait_timeout, return_when=FIRST_COMPLETED
-            )
+            completed, pending = wait(pending, timeout=1.0, return_when=FIRST_COMPLETED)
             for future in completed:
                 result += future.result()
                 # we could check outside the loop, but that means more

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -61,9 +61,6 @@ from pydvl.parallel import (
     ParallelBackend,
     ParallelConfig,
     _maybe_init_parallel_backend,
-    effective_n_jobs,
-    init_executor,
-    init_parallel_backend,
 )
 from pydvl.utils.numeric import random_powerset
 from pydvl.utils.progress import repeat_indices
@@ -211,7 +208,7 @@ def permutation_montecarlo_shapley(
 
     parallel_backend = _maybe_init_parallel_backend(parallel_backend, config)
     u = parallel_backend.put(u)
-    max_workers = effective_n_jobs(n_jobs, config)
+    max_workers = parallel_backend.effective_n_jobs(n_jobs)
     n_submitted_jobs = 2 * max_workers  # number of jobs in the executor's queue
 
     seed_sequence = ensure_seed_sequence(seed)

--- a/src/pydvl/value/shapley/montecarlo.py
+++ b/src/pydvl/value/shapley/montecarlo.py
@@ -201,6 +201,11 @@ def permutation_montecarlo_shapley(
 
     Returns:
         Object with the data values.
+
+    !!! tip "Changed in version 0.9.0"
+        Deprecated `config` argument and added a `parallel_backend`
+        argument to allow users to pass the Parallel Backend instance
+        directly.
     """
     algorithm = "permutation_montecarlo_shapley"
 
@@ -355,6 +360,11 @@ def combinatorial_montecarlo_shapley(
 
     Returns:
         Object with the data values.
+
+    !!! tip "Changed in version 0.9.0"
+        Deprecated `config` argument and added a `parallel_backend`
+        argument to allow users to pass the Parallel Backend instance
+        directly.
     """
     parallel_backend = _maybe_init_parallel_backend(parallel_backend, config)
 

--- a/src/pydvl/value/shapley/naive.py
+++ b/src/pydvl/value/shapley/naive.py
@@ -151,6 +151,11 @@ def combinatorial_exact_shapley(
 
     Returns:
         Object with the data values.
+
+    !!! tip "Changed in version 0.9.0"
+        Deprecated `config` argument and added a `parallel_backend`
+        argument to allow users to pass the Parallel Backend instance
+        directly.
     """
     # Arbitrary choice, will depend on time required, caching, etc.
     if len(u.data) // n_jobs > 20:

--- a/src/pydvl/value/shapley/owen.py
+++ b/src/pydvl/value/shapley/owen.py
@@ -192,6 +192,11 @@ def owen_sampling_shapley(
     !!! tip "Changed in version 0.5.0"
         Support for parallel computation and enable antithetic sampling.
 
+    !!! tip "Changed in version 0.9.0"
+        Deprecated `config` argument and added a `parallel_backend`
+        argument to allow users to pass the Parallel Backend instance
+        directly.
+
     """
     parallel_backend = _maybe_init_parallel_backend(parallel_backend, config)
 

--- a/src/pydvl/value/shapley/owen.py
+++ b/src/pydvl/value/shapley/owen.py
@@ -12,9 +12,15 @@ from functools import reduce
 from typing import Optional, Sequence
 
 import numpy as np
+from deprecate import deprecated
 from numpy.typing import NDArray
 
-from pydvl.parallel import MapReduceJob, ParallelConfig
+from pydvl.parallel import (
+    MapReduceJob,
+    ParallelBackend,
+    ParallelConfig,
+    _maybe_init_parallel_backend,
+)
 from pydvl.utils import Utility, random_powerset
 from pydvl.utils.progress import repeat_indices
 from pydvl.utils.types import Seed
@@ -106,6 +112,12 @@ def _owen_sampling_shapley(
     return result
 
 
+@deprecated(
+    target=True,
+    args_mapping={"config": "config"},
+    deprecated_in="0.9.0",
+    remove_in="0.10.0",
+)
 def owen_sampling_shapley(
     u: Utility,
     n_samples: int,
@@ -113,7 +125,8 @@ def owen_sampling_shapley(
     *,
     method: OwenAlgorithm = OwenAlgorithm.Standard,
     n_jobs: int = 1,
-    config: ParallelConfig = ParallelConfig(),
+    parallel_backend: Optional[ParallelBackend] = None,
+    config: Optional[ParallelConfig] = None,
     progress: bool = False,
     seed: Optional[Seed] = None
 ) -> ValuationResult:
@@ -161,8 +174,13 @@ def owen_sampling_shapley(
             $q \in [0,0.5]$ and correlated samples
         n_jobs: Number of parallel jobs to use. Each worker receives a chunk
             of the total of `max_q` values for q.
-        config: Object configuring parallel computation, with cluster address,
-            number of cpus, etc.
+        parallel_backend: Parallel backend instance to use
+            for parallelizing computations. If `None`,
+            use [JoblibParallelBackend][pydvl.parallel.backends.JoblibParallelBackend] backend.
+            See the [Parallel Backends][pydvl.parallel.backends] package
+            for available options.
+        config: (**DEPRECATED**) Object configuring parallel computation,
+            with cluster address, number of cpus, etc.
         progress: Whether to display progress bars for each job.
         seed: Either an instance of a numpy random number generator or a seed for it.
 
@@ -175,6 +193,8 @@ def owen_sampling_shapley(
         Support for parallel computation and enable antithetic sampling.
 
     """
+    parallel_backend = _maybe_init_parallel_backend(parallel_backend, config)
+
     map_reduce_job: MapReduceJob[NDArray, ValuationResult] = MapReduceJob(
         u.data.indices,
         map_func=_owen_sampling_shapley,
@@ -187,7 +207,7 @@ def owen_sampling_shapley(
             progress=progress,
         ),
         n_jobs=n_jobs,
-        config=config,
+        parallel_backend=parallel_backend,
     )
 
     return map_reduce_job(seed=seed)

--- a/tests/parallel/test_parallel.py
+++ b/tests/parallel/test_parallel.py
@@ -8,27 +8,19 @@ import numpy as np
 import pytest
 
 from pydvl.parallel import MapReduceJob, init_parallel_backend
-from pydvl.parallel.backend import effective_n_jobs
 from pydvl.parallel.futures import init_executor
 from pydvl.utils.types import Seed
 
 from ..conftest import num_workers
 
 
-def test_effective_n_jobs(parallel_config):
-    parallel_backend = init_parallel_backend(parallel_config)
+def test_effective_n_jobs(parallel_backend):
     assert parallel_backend.effective_n_jobs(1) == 1
     assert parallel_backend.effective_n_jobs(4) == min(4, num_workers())
-    if parallel_config.address is None:
-        assert parallel_backend.effective_n_jobs(-1) == num_workers()
-    else:
-        assert parallel_backend.effective_n_jobs(-1) == num_workers()
+    assert parallel_backend.effective_n_jobs(-1) == num_workers()
 
     for n_jobs in [-1, 1, 2]:
-        assert parallel_backend.effective_n_jobs(n_jobs) == effective_n_jobs(
-            n_jobs, parallel_config
-        )
-        assert effective_n_jobs(n_jobs, parallel_config) > 0
+        assert parallel_backend.effective_n_jobs(n_jobs) > 0
 
     with pytest.raises(ValueError):
         parallel_backend.effective_n_jobs(0)

--- a/tests/value/conftest.py
+++ b/tests/value/conftest.py
@@ -1,3 +1,4 @@
+import joblib
 import numpy as np
 import pytest
 from numpy.typing import NDArray
@@ -6,6 +7,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import PolynomialFeatures
 from sklearn.utils import Bunch
 
+from pydvl.parallel import JoblibParallelBackend
 from pydvl.parallel.config import ParallelConfig
 from pydvl.utils import Dataset, SupervisedModel, Utility
 from pydvl.utils.caching import InMemoryCacheBackend
@@ -162,6 +164,12 @@ def linear_shapley(cache, linear_dataset, scorer, n_jobs):
 @pytest.fixture(scope="module")
 def parallel_config():
     yield ParallelConfig(backend="joblib", n_cpus_local=num_workers(), wait_timeout=0.1)
+
+
+@pytest.fixture(scope="module")
+def parallel_backend():
+    with joblib.parallel_config(n_jobs=num_workers()):
+        yield JoblibParallelBackend()
 
 
 @pytest.fixture()

--- a/tests/value/conftest.py
+++ b/tests/value/conftest.py
@@ -162,11 +162,6 @@ def linear_shapley(cache, linear_dataset, scorer, n_jobs):
 
 
 @pytest.fixture(scope="module")
-def parallel_config():
-    yield ParallelConfig(backend="joblib", n_cpus_local=num_workers(), wait_timeout=0.1)
-
-
-@pytest.fixture(scope="module")
 def parallel_backend():
     with joblib.parallel_config(n_jobs=num_workers()):
         yield JoblibParallelBackend()

--- a/tests/value/least_core/test_common.py
+++ b/tests/value/least_core/test_common.py
@@ -12,7 +12,7 @@ from .. import check_values
     [("miner", {"n_players": 5})],
     indirect=True,
 )
-def test_lc_solve_problems(test_game, n_jobs, parallel_config):
+def test_lc_solve_problems(test_game, n_jobs, parallel_backend):
     """Test solving LeastCoreProblems in parallel."""
 
     n_problems = n_jobs
@@ -22,7 +22,7 @@ def test_lc_solve_problems(test_game, n_jobs, parallel_config):
         test_game.u,
         algorithm="test_lc",
         n_jobs=n_jobs,
-        config=parallel_config,
+        parallel_backend=parallel_backend,
     )
     assert len(solutions) == n_problems
 

--- a/tests/value/loo/test_loo.py
+++ b/tests/value/loo/test_loo.py
@@ -6,9 +6,9 @@ from .. import check_total_value, check_values
 
 
 @pytest.mark.parametrize("num_samples", [10, 100])
-def test_loo(num_samples: int, n_jobs: int, parallel_config, analytic_loo):
+def test_loo(num_samples: int, n_jobs: int, parallel_backend, analytic_loo):
     """Compares LOO with analytic values in a dummy model"""
     u, exact_values = analytic_loo
-    values = compute_loo(u, n_jobs=n_jobs, config=parallel_config, progress=False)
+    values = compute_loo(u, n_jobs=n_jobs, parallel_backend=parallel_backend)
     check_total_value(u, values, rtol=0.1)
     check_values(values, exact_values, rtol=0.1)

--- a/tests/value/shapley/test_montecarlo.py
+++ b/tests/value/shapley/test_montecarlo.py
@@ -53,7 +53,7 @@ log = logging.getLogger(__name__)
 )
 def test_games(
     test_game,
-    parallel_config,
+    parallel_backend,
     n_jobs,
     fun: ShapleyMode,
     rtol: float,
@@ -79,7 +79,7 @@ def test_games(
         test_game.u,
         mode=fun,
         n_jobs=n_jobs,
-        config=parallel_config,
+        parallel_backend=parallel_backend,
         seed=seed,
         progress=True,
         **kwargs
@@ -110,7 +110,7 @@ def test_games(
 )
 def test_seed(
     test_game,
-    parallel_config: ParallelConfig,
+    parallel_backend: ParallelConfig,
     n_jobs: int,
     fun: ShapleyMode,
     kwargs: dict,
@@ -122,7 +122,7 @@ def test_seed(
         test_game.u,
         mode=fun,
         n_jobs=n_jobs,
-        config=parallel_config,
+        parallel_backend=parallel_backend,
         seeds=(seed, seed, seed_alt),
         **deepcopy(kwargs)
     )

--- a/tests/value/shapley/test_truncated.py
+++ b/tests/value/shapley/test_truncated.py
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 )
 def test_games(
     test_game,
-    parallel_config,
+    parallel_backend,
     n_jobs,
     done,
     truncation_cls,
@@ -52,7 +52,7 @@ def test_games(
         done=done,
         truncation=truncation,
         n_jobs=n_jobs,
-        config=parallel_config,
+        parallel_backend=parallel_backend,
         seed=seed,
         progress=True,
     )

--- a/tests/value/test_semivalues.py
+++ b/tests/value/test_semivalues.py
@@ -104,7 +104,7 @@ def test_coefficients(n: int, coefficient: SVCoefficient):
 @pytest.mark.parametrize("coefficient", [shapley_coefficient, beta_coefficient(1, 1)])
 def test_games_shapley_deterministic(
     test_game,
-    parallel_config,
+    parallel_backend,
     n_jobs,
     sampler: Type[PowersetSampler],
     coefficient: SVCoefficient,
@@ -118,7 +118,7 @@ def test_games_shapley_deterministic(
         criterion,
         skip_converged=True,
         n_jobs=n_jobs,
-        config=parallel_config,
+        parallel_backend=parallel_backend,
         progress=True,
     )
     exact_values = test_game.shapley_values()
@@ -145,7 +145,7 @@ def test_games_shapley_deterministic(
 @pytest.mark.parametrize("coefficient", [shapley_coefficient, beta_coefficient(1, 1)])
 def test_games_shapley(
     test_game,
-    parallel_config,
+    parallel_backend,
     n_jobs,
     sampler: Type[PowersetSampler],
     coefficient: SVCoefficient,
@@ -159,7 +159,7 @@ def test_games_shapley(
         criterion,
         skip_converged=True,
         n_jobs=n_jobs,
-        config=parallel_config,
+        parallel_backend=parallel_backend,
         progress=True,
     )
 
@@ -196,7 +196,7 @@ def test_shapley_batch_size(
     coefficient: SVCoefficient,
     batch_size: int,
     n_jobs: int,
-    parallel_config: ParallelConfig,
+    parallel_backend: ParallelConfig,
     seed: Seed,
 ):
     timed_fn = timed(compute_generic_semivalues)
@@ -208,7 +208,7 @@ def test_shapley_batch_size(
         skip_converged=True,
         n_jobs=n_jobs,
         batch_size=1,
-        config=parallel_config,
+        parallel_backend=parallel_backend,
     )
     total_seconds_single_batch = timed_fn.execution_time
 
@@ -220,7 +220,7 @@ def test_shapley_batch_size(
         skip_converged=True,
         n_jobs=n_jobs,
         batch_size=batch_size,
-        config=parallel_config,
+        parallel_backend=parallel_backend,
     )
     total_seconds_multi_batch = timed_fn.execution_time
     assert total_seconds_multi_batch < total_seconds_single_batch * 1.1
@@ -246,7 +246,7 @@ def test_banzhaf(
     analytic_banzhaf,
     sampler: Type[PowersetSampler],
     n_jobs: int,
-    parallel_config: ParallelConfig,
+    parallel_backend: ParallelConfig,
     seed,
 ):
     u, exact_values = analytic_banzhaf
@@ -258,6 +258,6 @@ def test_banzhaf(
         criterion,
         skip_converged=True,
         n_jobs=n_jobs,
-        config=parallel_config,
+        parallel_backend=parallel_backend,
     )
     check_values(values, exact_values, rtol=0.2)


### PR DESCRIPTION
### Description

This PR closes #385

### Changes

- Deprecated `config` argument of parallel backend classes, ray future executor and `MapReduceJob` class.
- Allowed instantiating parallel backend classes directly and deprecated `init_parallel_backend` function.
- Updated docstrings.
- Adapted all methods to use `parallel_backend` and deprecate `config` argument.

### Checklist

- [x] Wrote Unit tests (if necessary)
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- [ ] ~If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~
