### PR TITLE
Make default argument for config None and instantiate in init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `FutureWarning` for `ParallelConfig` constantly raised without actually 
+  instantiating the object
+  [PR #562](https://github.com/aai-institute/pyDVL/pull/562)
+
 ## 0.9.0 - 🆕 New methods, better docs and bugfixes 📚🐞
 
 ### Added

--- a/src/pydvl/parallel/futures/__init__.py
+++ b/src/pydvl/parallel/futures/__init__.py
@@ -21,7 +21,7 @@ __all__ = ["init_executor"]
 )
 def init_executor(
     max_workers: Optional[int] = None,
-    config: ParallelConfig = ParallelConfig(),
+    config: Optional[ParallelConfig] = None,
     **kwargs,
 ) -> Generator[Executor, None, None]:
     """Initializes a futures executor for the given parallel configuration.
@@ -50,6 +50,10 @@ def init_executor(
         assert results == [1, 2, 3, 4, 5]
         ```
     """
+
+    if config is None:
+        config = ParallelConfig()
+
     try:
         cls = ParallelBackend.BACKENDS[config.backend]
         with cls.executor(max_workers=max_workers, config=config, **kwargs) as e:


### PR DESCRIPTION
### Description

This PR closes #561 

### Changes

- Remove instantiation from default argument

### Checklist

- [x] ~Wrote Unit tests (if necessary)~
- [x] ~Updated Documentation (if necessary)~
- [x] Updated Changelog
- [x] ~If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~
