### PR TITLE
Improve logging for influence modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,29 @@
 
 ### Added
 
+- Add progress bars to the computation of `LazyChunkSequence` and
+  `NestedLazyChunkSequence` 
+  [PR #567](https://github.com/aai-institute/pyDVL/pull/567)
 - Add a device fixture for `pytest`, which depending on the availability and 
   user input (`pytest --with-cuda`) resolves to cuda device
   [PR #574](https://github.com/aai-institute/pyDVL/pull/574)
 
 ### Fixed
 
+- Fixed logging issue in decorator `log_duration`
+  [PR #567](https://github.com/aai-institute/pyDVL/pull/567)
 - Fixed missing move of tensors to model device in `EkfacInfluence` 
   implementation [PR #570](https://github.com/aai-institute/pyDVL/pull/570)
 - Missing move to device of `preconditioner` in `CgInfluence` implementation
   [PR #572](https://github.com/aai-institute/pyDVL/pull/572)
+
+### Changed
+
+- Changed logging behavior of iterative methods `LissaInfluence` and
+  `CgInfluence` to warn on not achieving desired tolerance within `maxiter`,
+  add parameter `warn_on_max_iteration` to set the level for this information
+  to `logging.DEBUG`
+  [PR #567](https://github.com/aai-institute/pyDVL/pull/567)
 
 ## 0.9.1 - Bug fixes, logging improvement
 

--- a/src/pydvl/influence/base_influence_function_model.py
+++ b/src/pydvl/influence/base_influence_function_model.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Collection, Generic, Iterable, Optional, Type, TypeVar
 
+__all__ = ["InfluenceMode"]
+
 
 class InfluenceMode(str, Enum):
     """

--- a/src/pydvl/influence/influence_calculator.py
+++ b/src/pydvl/influence/influence_calculator.py
@@ -619,8 +619,14 @@ class SequentialInfluenceCalculator:
         Returns:
             A lazy data structure representing the chunks of the resulting tensor
         """
+        try:
+            len_iterable = len(data_iterable)
+        except Exception as e:
+            logger.debug(f"Failed to retrieve len of data iterable: {e}")
+            len_iterable = None
+
         tensors_gen_factory = partial(self._influence_factors_gen, data_iterable)
-        return LazyChunkSequence(tensors_gen_factory)
+        return LazyChunkSequence(tensors_gen_factory, len_generator=len_iterable)
 
     def _influences_gen(
         self,
@@ -677,7 +683,15 @@ class SequentialInfluenceCalculator:
             mode,
         )
 
-        return NestedLazyChunkSequence(nested_tensor_gen_factory)
+        try:
+            len_iterable = len(test_data_iterable)
+        except Exception as e:
+            logger.debug(f"Failed to retrieve len of test data iterable: {e}")
+            len_iterable = None
+
+        return NestedLazyChunkSequence(
+            nested_tensor_gen_factory, len_outer_generator=len_iterable
+        )
 
     def _influences_from_factors_gen(
         self,
@@ -735,4 +749,13 @@ class SequentialInfluenceCalculator:
             train_data_iterable,
             mode,
         )
-        return NestedLazyChunkSequence(nested_tensor_gen)
+
+        try:
+            len_iterable = len(z_test_factors)
+        except Exception as e:
+            logger.debug(f"Failed to retrieve len of factors iterable: {e}")
+            len_iterable = None
+
+        return NestedLazyChunkSequence(
+            nested_tensor_gen, len_outer_generator=len_iterable
+        )

--- a/src/pydvl/influence/influence_calculator.py
+++ b/src/pydvl/influence/influence_calculator.py
@@ -7,7 +7,7 @@ which is mapped over collection of chunks.
 
 import logging
 from functools import partial
-from typing import Generator, Iterable, Optional, Tuple, Type, Union
+from typing import Generator, Iterable, Optional, Sized, Tuple, Type, Union, cast
 
 import distributed
 from dask import array as da
@@ -620,7 +620,7 @@ class SequentialInfluenceCalculator:
             A lazy data structure representing the chunks of the resulting tensor
         """
         try:
-            len_iterable = len(data_iterable)
+            len_iterable = len(cast(Sized, data_iterable))
         except Exception as e:
             logger.debug(f"Failed to retrieve len of data iterable: {e}")
             len_iterable = None
@@ -684,7 +684,7 @@ class SequentialInfluenceCalculator:
         )
 
         try:
-            len_iterable = len(test_data_iterable)
+            len_iterable = len(cast(Sized, test_data_iterable))
         except Exception as e:
             logger.debug(f"Failed to retrieve len of test data iterable: {e}")
             len_iterable = None
@@ -751,7 +751,7 @@ class SequentialInfluenceCalculator:
         )
 
         try:
-            len_iterable = len(z_test_factors)
+            len_iterable = len(cast(Sized, z_test_factors))
         except Exception as e:
             logger.debug(f"Failed to retrieve len of factors iterable: {e}")
             len_iterable = None

--- a/src/pydvl/influence/torch/influence_function_model.py
+++ b/src/pydvl/influence/torch/influence_function_model.py
@@ -41,6 +41,15 @@ from .util import (
     flatten_dimensions,
 )
 
+__all__ = [
+    "DirectInfluence",
+    "CgInfluence",
+    "LissaInfluence",
+    "ArnoldiInfluence",
+    "EkfacInfluence",
+    "NystroemSketchInfluence",
+]
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/pydvl/utils/progress.py
+++ b/src/pydvl/utils/progress.py
@@ -49,13 +49,11 @@ def log_duration(_func=None, *, log_level=logging.DEBUG):
         @wraps(func)
         def wrapper_log_duration(*args, **kwargs):
             func_name = func.__qualname__
-            duration_logger = logging.getLogger(func_name)
-            duration_logger.setLevel(log_level)
-            duration_logger.log(log_level, f"Function '{func_name}' is starting.")
+            logger.log(log_level, f"Function '{func_name}' is starting.")
             start_time = time()
             result = func(*args, **kwargs)
             duration = time() - start_time
-            duration_logger.log(
+            logger.log(
                 log_level,
                 f"Function '{func_name}' completed. " f"Duration: {duration:.2f} sec",
             )


### PR DESCRIPTION
### Description

This PR closes #575  closes #576  closes #577 

### Changes

- Fix bug in decorator `log_duration`, to log depending on the module's logger
- Improve logging for iterative methods `LissaInfluence` and `CgInfluence`, add parameter `warn_on_max_iteration` to
  display a warning if desired toelrance is not achieved within `maxiter`
- Add `tqdm` progress bars to the computation of `LazyChunkSequence` and `NestedLazyChunkSequence` (which are returned from calls to `SequentialInfluenceCalculator`) 

### Checklist

- [x] ~Wrote Unit tests (if necessary)~
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- [x] ~If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~
