### PR TITLE
Fix/552 ekfac bug mps osx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   implementation [PR #570](https://github.com/aai-institute/pyDVL/pull/570)
 - Missing move to device of `preconditioner` in `CgInfluence` implementation
   [PR #572](https://github.com/aai-institute/pyDVL/pull/572)
+- Raise a more specific error message, when a `RunTimeError` occurs in 
+  `torch.linalg.eigh`, so the user can check if it is related to a known
+  issue
+  [PR #578](https://github.com/aai-institute/pyDVL/pull/578)
 
 ## 0.9.1 - Bug fixes, logging improvement
 

--- a/src/pydvl/influence/torch/influence_function_model.py
+++ b/src/pydvl/influence/torch/influence_function_model.py
@@ -39,6 +39,7 @@ from .util import (
     EkfacRepresentation,
     empirical_cross_entropy_loss_fn,
     flatten_dimensions,
+    safe_torch_linalg_eigh,
 )
 
 logger = logging.getLogger(__name__)
@@ -1227,8 +1228,8 @@ class EkfacInfluence(TorchInfluenceFunctionModel):
         layers_evect_g = {}
         layers_diags = {}
         for key in self.active_layers.keys():
-            evals_a, evecs_a = torch.linalg.eigh(forward_x[key])
-            evals_g, evecs_g = torch.linalg.eigh(grad_y[key])
+            evals_a, evecs_a = safe_torch_linalg_eigh(forward_x[key])
+            evals_g, evecs_g = safe_torch_linalg_eigh(grad_y[key])
             layers_evecs_a[key] = evecs_a
             layers_evect_g[key] = evecs_g
             layers_diags[key] = torch.kron(evals_g.view(-1, 1), evals_a.view(-1, 1))

--- a/src/pydvl/influence/torch/util.py
+++ b/src/pydvl/influence/torch/util.py
@@ -530,7 +530,8 @@ def safe_torch_linalg_eigh(*args, **kwargs):
     A wrapper around `torch.linalg.eigh` that safely handles potential runtime errors
     by raising a custom `TorchLinalgEighException` with more context,
     especially related to the issues reported in
-    https://github.com/pytorch/pytorch/issues/92141.
+    [https://github.com/pytorch/pytorch/issues/92141](
+    https://github.com/pytorch/pytorch/issues/92141).
 
     Args:
         *args: Positional arguments passed to `torch.linalg.eigh`.
@@ -549,7 +550,9 @@ def safe_torch_linalg_eigh(*args, **kwargs):
 class TorchLinalgEighException(Exception):
     """
     Exception to wrap a RunTimeError raised by torch.linalg.eigh, when used
-    with large matrices, see https://github.com/pytorch/pytorch/issues/92141
+    with large matrices,
+    see [https://github.com/pytorch/pytorch/issues/92141](
+    https://github.com/pytorch/pytorch/issues/92141)
     """
 
     def __init__(self, original_exception: RuntimeError):

--- a/src/pydvl/utils/exceptions.py
+++ b/src/pydvl/utils/exceptions.py
@@ -1,0 +1,34 @@
+from functools import wraps
+from typing import TypeVar, Type, Callable
+
+CatchExceptionType = TypeVar("CatchExceptionType", bound=BaseException)
+RaiseExceptionType = TypeVar("RaiseExceptionType", bound=BaseException)
+
+
+def catch_and_raise_exception(
+    catch_exception_type: Type[CatchExceptionType],
+    raise_exception_factory: Callable[[CatchExceptionType], RaiseExceptionType],
+) -> Callable:
+    """
+    A decorator that catches exceptions of a specified exception type and raises
+    another specified exception.
+
+    Args:
+        catch_exception_type: The type of the exception to catch.
+        raise_exception_factory: A factory function that creates a new exception.
+
+    Returns:
+        A decorator function that wraps the target function.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except catch_exception_type as e:
+                raise raise_exception_factory(e) from e
+
+        return wrapper
+
+    return decorator

--- a/src/pydvl/utils/exceptions.py
+++ b/src/pydvl/utils/exceptions.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import TypeVar, Type, Callable
+from typing import Callable, Type, TypeVar
 
 CatchExceptionType = TypeVar("CatchExceptionType", bound=BaseException)
 RaiseExceptionType = TypeVar("RaiseExceptionType", bound=BaseException)
@@ -19,6 +19,32 @@ def catch_and_raise_exception(
 
     Returns:
         A decorator function that wraps the target function.
+
+    ??? Example
+
+        ```python
+            @catch_and_raise_exception(RuntimeError, lambda e: TorchLinalgEighException(e))
+            def safe_torch_linalg_eigh(*args, **kwargs):
+                '''
+                A wrapper around `torch.linalg.eigh` that safely handles potential runtime errors
+                by raising a custom `TorchLinalgEighException` with more context,
+                especially related to the issues reported in
+                https://github.com/pytorch/pytorch/issues/92141.
+
+                Args:
+                *args: Positional arguments passed to `torch.linalg.eigh`.
+                **kwargs: Keyword arguments passed to `torch.linalg.eigh`.
+
+                Returns:
+                The result of calling `torch.linalg.eigh` with the provided arguments.
+
+                Raises:
+                TorchLinalgEighException: If a `RuntimeError` occurs during the execution of
+                `torch.linalg.eigh`.
+                '''
+                return torch.linalg.eigh(*args, **kwargs)
+
+        ```
     """
 
     def decorator(func):

--- a/src/pydvl/utils/exceptions.py
+++ b/src/pydvl/utils/exceptions.py
@@ -23,27 +23,26 @@ def catch_and_raise_exception(
     ??? Example
 
         ```python
-            @catch_and_raise_exception(RuntimeError, lambda e: TorchLinalgEighException(e))
-            def safe_torch_linalg_eigh(*args, **kwargs):
-                '''
-                A wrapper around `torch.linalg.eigh` that safely handles potential runtime errors
-                by raising a custom `TorchLinalgEighException` with more context,
-                especially related to the issues reported in
-                https://github.com/pytorch/pytorch/issues/92141.
+        @catch_and_raise_exception(RuntimeError, lambda e: TorchLinalgEighException(e))
+        def safe_torch_linalg_eigh(*args, **kwargs):
+            '''
+            A wrapper around `torch.linalg.eigh` that safely handles potential runtime errors
+            by raising a custom `TorchLinalgEighException` with more context,
+            especially related to the issues reported in
+            https://github.com/pytorch/pytorch/issues/92141.
 
-                Args:
-                *args: Positional arguments passed to `torch.linalg.eigh`.
-                **kwargs: Keyword arguments passed to `torch.linalg.eigh`.
+            Args:
+            *args: Positional arguments passed to `torch.linalg.eigh`.
+            **kwargs: Keyword arguments passed to `torch.linalg.eigh`.
 
-                Returns:
-                The result of calling `torch.linalg.eigh` with the provided arguments.
+            Returns:
+            The result of calling `torch.linalg.eigh` with the provided arguments.
 
-                Raises:
-                TorchLinalgEighException: If a `RuntimeError` occurs during the execution of
-                `torch.linalg.eigh`.
-                '''
-                return torch.linalg.eigh(*args, **kwargs)
-
+            Raises:
+            TorchLinalgEighException: If a `RuntimeError` occurs during the execution of
+            `torch.linalg.eigh`.
+            '''
+            return torch.linalg.eigh(*args, **kwargs)
         ```
     """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import platform
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Optional, Tuple
 
@@ -264,3 +265,7 @@ def pytest_terminal_summary(
 ):
     tolerate_session = terminalreporter.config._tolerate_session
     tolerate_session.display(terminalreporter)
+
+
+def is_osx_arm64():
+    return platform.system() == "Darwin" and platform.machine() == "arm64"


### PR DESCRIPTION
### Description

This PR closes #552 

### Changes

- add a decorator to catch exceptions of a specific type and raise a more concrete exception type
- add `TorchLinalgEighException`
- add `safe_torch_linalg_eigh` which is decorated to raise the above exception, if a `RunTimeError` occurs in calling torch.linalg.eigh  
- add tests, where the exception testing is only pulled out on osx-arm64

### Checklist

- [x] Wrote Unit tests (if necessary)
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- [x] ~If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~
