### PR TITLE
Add a temporary fix to handle an edge case in the test test_classwise…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
   `torch.linalg.eigh`, so the user can check if it is related to a known
   issue
   [PR #578](https://github.com/aai-institute/pyDVL/pull/578)
+- Fix an edge case (empty train data) in the test 
+  `test_classwise_scorer_accuracies_manual_derivation`, which resulted
+  in undefined behavior (`np.nan` to `int` conversion with different results
+  depending on OS)
+  [PR #579](https://github.com/aai-institute/pyDVL/pull/579)
 
 ### Changed
 

--- a/tests/value/shapley/test_classwise.py
+++ b/tests/value/shapley/test_classwise.py
@@ -266,6 +266,14 @@ def test_classwise_scorer_accuracies_manual_derivation(
     for set_zero_idx in range(len(subsets_zero)):
         for set_one_idx in range(len(subsets_one)):
             indices = list(subsets_zero[set_zero_idx] + subsets_one[set_one_idx])
+
+            # TODO the powersets subsets_zero, subsets_one contain the empty set, having
+            #  this leads to an empty index set with the consequence of undefined
+            #  behavior (due to nan values). This is NOT the correct fix, this test
+            #  must be completely revised!
+            if len(indices) == 0:
+                continue
+
             (
                 x_train,
                 y_train,


### PR DESCRIPTION
### Description

This PR closes #474

### Changes

- FIx an edge case in the test test_classwise_scorer_accuracies_manual_derivation, empty train data leads to undefined behavior due to occurrence of `np.nan` and different resulting int conversions depending on operation system.

### Checklist

- [x] ~Wrote Unit tests (if necessary)~
- [x] ~Updated Documentation (if necessary)~
- [x] Updated Changelog
- [x] ~If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~
