### PR TITLE
Replace np.float_ with np.float64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 - Extend `NystroemSketchInfluence` with block-diagonal and Gauss-Newton 
   approximation
   [PR #596](https://github.com/aai-institute/pyDVL/pull/596)
+
+## Fixed
+- Replace `np.float_` with `np.float64` and `np.alltrue` with `np.all`,
+  as the old aliases are removed in NumPy 2.0
+  [PR #604](https://github.com/aai-institute/pyDVL/pull/604)
   
 ## Changed
 

--- a/notebooks/support/common.py
+++ b/notebooks/support/common.py
@@ -21,16 +21,16 @@ logger = logging.getLogger(__name__)
 
 
 def plot_gaussian_blobs(
-    train_ds: Tuple[NDArray[np.float_], NDArray[np.int_]],
-    test_ds: Tuple[NDArray[np.float_], NDArray[np.int_]],
-    x_min: Optional[NDArray[np.float_]] = None,
-    x_max: Optional[NDArray[np.float_]] = None,
+    train_ds: Tuple[NDArray[np.float64], NDArray[np.int_]],
+    test_ds: Tuple[NDArray[np.float64], NDArray[np.int_]],
+    x_min: Optional[NDArray[np.float64]] = None,
+    x_max: Optional[NDArray[np.float64]] = None,
     *,
     xlabel: Optional[str] = None,
     ylabel: Optional[str] = None,
     legend_title: Optional[str] = None,
     vline: Optional[float] = None,
-    line: Optional[NDArray[np.float_]] = None,
+    line: Optional[NDArray[np.float64]] = None,
     suptitle: Optional[str] = None,
     s: Optional[float] = None,
     figsize: Tuple[int, int] = (20, 10),
@@ -104,15 +104,15 @@ def plot_gaussian_blobs(
 
 
 def plot_influences(
-    x: NDArray[np.float_],
-    influences: NDArray[np.float_],
+    x: NDArray[np.float64],
+    influences: NDArray[np.float64],
     corrupted_indices: Optional[List[int]] = None,
     *,
     ax: Optional[plt.Axes] = None,
     xlabel: Optional[str] = None,
     ylabel: Optional[str] = None,
     legend_title: Optional[str] = None,
-    line: Optional[NDArray[np.float_]] = None,
+    line: Optional[NDArray[np.float64]] = None,
     suptitle: Optional[str] = None,
     colorbar_limits: Optional[Tuple] = None,
 ) -> plt.Axes:
@@ -403,7 +403,7 @@ def plot_sample_images(dataset: pd.DataFrame, n_images_per_class: int = 3):
 
 
 def plot_lowest_highest_influence_images(
-    subset_influences: NDArray[np.float_],
+    subset_influences: NDArray[np.float64],
     subset_images: List[JpegImageFile],
     num_to_plot: int,
 ):
@@ -454,7 +454,7 @@ def plot_losses(losses: Losses):
 def corrupt_imagenet(
     dataset: pd.DataFrame,
     fraction_to_corrupt: float,
-    avg_influences: NDArray[np.float_],
+    avg_influences: NDArray[np.float64],
 ) -> Tuple[pd.DataFrame, Dict[Any, List[int]]]:
     """Given the preprocessed tiny imagenet dataset (or a subset of it), 
     it takes a fraction of the images with the highest influence and (randomly)
@@ -494,7 +494,7 @@ def corrupt_imagenet(
 def compute_mean_corrupted_influences(
     corrupted_dataset: pd.DataFrame,
     corrupted_indices: Dict[Any, List[int]],
-    avg_corrupted_influences: NDArray[np.float_],
+    avg_corrupted_influences: NDArray[np.float64],
 ) -> pd.DataFrame:
     """Given a corrupted dataset, it returns a dataframe with average influence for each class,
     separating corrupted and original points.
@@ -534,7 +534,7 @@ def compute_mean_corrupted_influences(
 def plot_corrupted_influences_distribution(
     corrupted_dataset: pd.DataFrame,
     corrupted_indices: Dict[Any, List[int]],
-    avg_corrupted_influences: NDArray[np.float_],
+    avg_corrupted_influences: NDArray[np.float64],
     figsize: Tuple[int, int] = (16, 8),
 ):
     """Given a corrupted dataset, plots the histogram with the distribution of

--- a/notebooks/support/types.py
+++ b/notebooks/support/types.py
@@ -5,5 +5,5 @@ from numpy.typing import NDArray
 
 
 class Losses(NamedTuple):
-    training: NDArray[np.float_]
-    validation: NDArray[np.float_]
+    training: NDArray[np.float64]
+    validation: NDArray[np.float64]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyDeprecate>=0.3.2
-numpy>=1.20
+numpy>=1.20,<2
 pandas>=1.3
 scikit-learn
 scipy>=1.7.0

--- a/src/pydvl/reporting/plots.py
+++ b/src/pydvl/reporting/plots.py
@@ -272,7 +272,7 @@ def plot_shapley(
 
 
 def plot_influence_distribution(
-    influences: NDArray[np.float_], index: int, title_extra: str = ""
+    influences: NDArray[np.float64], index: int, title_extra: str = ""
 ) -> plt.Axes:
     """Plots the histogram of the influence that all samples in the training set
     have over a single sample index.
@@ -292,7 +292,7 @@ def plot_influence_distribution(
 
 
 def plot_influence_distribution_by_label(
-    influences: NDArray[np.float_], labels: NDArray[np.float_], title_extra: str = ""
+    influences: NDArray[np.float64], labels: NDArray[np.float64], title_extra: str = ""
 ):
     """Plots the histogram of the influence that all samples in the training set
     have over a single sample index, separated by labels.

--- a/src/pydvl/reporting/scores.py
+++ b/src/pydvl/reporting/scores.py
@@ -13,7 +13,7 @@ __all__ = ["compute_removal_score"]
 def compute_removal_score(
     u: Utility,
     values: ValuationResult,
-    percentages: Union[NDArray[np.float_], Iterable[float]],
+    percentages: Union[NDArray[np.float64], Iterable[float]],
     *,
     remove_best: bool = False,
     progress: bool = False,

--- a/src/pydvl/utils/numeric.py
+++ b/src/pydvl/utils/numeric.py
@@ -279,20 +279,20 @@ def running_moments(
 
 @overload
 def running_moments(
-    previous_avg: NDArray[np.float_],
-    previous_variance: NDArray[np.float_],
+    previous_avg: NDArray[np.float64],
+    previous_variance: NDArray[np.float64],
     count: int,
-    new_value: NDArray[np.float_],
-) -> Tuple[NDArray[np.float_], NDArray[np.float_]]:
+    new_value: NDArray[np.float64],
+) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
     ...
 
 
 def running_moments(
-    previous_avg: float | NDArray[np.float_],
-    previous_variance: float | NDArray[np.float_],
+    previous_avg: float | NDArray[np.float64],
+    previous_variance: float | NDArray[np.float64],
     count: int,
-    new_value: float | NDArray[np.float_],
-) -> Tuple[float | NDArray[np.float_], float | NDArray[np.float_]]:
+    new_value: float | NDArray[np.float64],
+) -> Tuple[float | NDArray[np.float64], float | NDArray[np.float64]]:
     """Uses Welford's algorithm to calculate the running average and variance of
      a set of numbers.
 
@@ -323,7 +323,7 @@ def running_moments(
 
 
 def top_k_value_accuracy(
-    y_true: NDArray[np.float_], y_pred: NDArray[np.float_], k: int = 3
+    y_true: NDArray[np.float64], y_pred: NDArray[np.float64], k: int = 3
 ) -> float:
     """Computes the top-k accuracy for the estimated values by comparing indices
     of the highest k values.

--- a/src/pydvl/utils/score.py
+++ b/src/pydvl/utils/score.py
@@ -64,7 +64,7 @@ class Scorer:
     """
 
     _name: str
-    range: NDArray[np.float_]
+    range: NDArray[np.float64]
 
     def __init__(
         self,

--- a/src/pydvl/value/least_core/common.py
+++ b/src/pydvl/value/least_core/common.py
@@ -29,8 +29,8 @@ logger = logging.getLogger(__name__)
 
 
 class LeastCoreProblem(NamedTuple):
-    utility_values: NDArray[np.float_]
-    A_lb: NDArray[np.float_]
+    utility_values: NDArray[np.float64]
+    A_lb: NDArray[np.float64]
 
 
 def lc_solve_problem(
@@ -113,7 +113,7 @@ def lc_solve_problem(
         solver_options=solver_options,
     )
 
-    values: Optional[NDArray[np.float_]]
+    values: Optional[NDArray[np.float64]]
 
     if subsidy is None:
         logger.debug("No values were found")
@@ -219,13 +219,13 @@ def lc_solve_problems(
 
 
 def _solve_least_core_linear_program(
-    A_eq: NDArray[np.float_],
-    b_eq: NDArray[np.float_],
-    A_lb: NDArray[np.float_],
-    b_lb: NDArray[np.float_],
+    A_eq: NDArray[np.float64],
+    b_eq: NDArray[np.float64],
+    A_lb: NDArray[np.float64],
+    b_lb: NDArray[np.float64],
     solver_options: dict,
     non_negative_subsidy: bool = False,
-) -> Tuple[Optional[NDArray[np.float_]], Optional[float]]:
+) -> Tuple[Optional[NDArray[np.float64]], Optional[float]]:
     r"""Solves the Least Core's linear program using cvxopt.
 
     $$
@@ -297,12 +297,12 @@ def _solve_least_core_linear_program(
 
 def _solve_egalitarian_least_core_quadratic_program(
     subsidy: float,
-    A_eq: NDArray[np.float_],
-    b_eq: NDArray[np.float_],
-    A_lb: NDArray[np.float_],
-    b_lb: NDArray[np.float_],
+    A_eq: NDArray[np.float64],
+    b_eq: NDArray[np.float64],
+    A_lb: NDArray[np.float64],
+    b_lb: NDArray[np.float64],
     solver_options: dict,
-) -> Optional[NDArray[np.float_]]:
+) -> Optional[NDArray[np.float64]]:
     r"""Solves the egalitarian Least Core's quadratic program using cvxopt.
 
     $$

--- a/src/pydvl/value/result.py
+++ b/src/pydvl/value/result.py
@@ -202,9 +202,9 @@ class ValuationResult(
     """
 
     _indices: NDArray[IndexT]
-    _values: NDArray[np.float_]
+    _values: NDArray[np.float64]
     _counts: NDArray[np.int_]
-    _variances: NDArray[np.float_]
+    _variances: NDArray[np.float64]
     _data: Dataset
     _names: NDArray[NameT]
     _algorithm: str
@@ -216,8 +216,8 @@ class ValuationResult(
     def __init__(
         self,
         *,
-        values: NDArray[np.float_],
-        variances: Optional[NDArray[np.float_]] = None,
+        values: NDArray[np.float64],
+        variances: Optional[NDArray[np.float64]] = None,
         counts: Optional[NDArray[np.int_]] = None,
         indices: Optional[NDArray[IndexT]] = None,
         data_names: Optional[Sequence[NameT] | NDArray[NameT]] = None,
@@ -299,20 +299,20 @@ class ValuationResult(
         self._sort_order = reverse
 
     @property
-    def values(self) -> NDArray[np.float_]:
+    def values(self) -> NDArray[np.float64]:
         """The values, possibly sorted."""
         return self._values[self._sort_positions]
 
     @property
-    def variances(self) -> NDArray[np.float_]:
+    def variances(self) -> NDArray[np.float64]:
         """The variances, possibly sorted."""
         return self._variances[self._sort_positions]
 
     @property
-    def stderr(self) -> NDArray[np.float_]:
+    def stderr(self) -> NDArray[np.float64]:
         """The raw standard errors, possibly sorted."""
         return cast(
-            NDArray[np.float_], np.sqrt(self.variances / np.maximum(1, self.counts))
+            NDArray[np.float64], np.sqrt(self.variances / np.maximum(1, self.counts))
         )
 
     @property

--- a/src/pydvl/value/shapley/classwise.py
+++ b/src/pydvl/value/shapley/classwise.py
@@ -166,7 +166,7 @@ class ClasswiseScorer(Scorer):
     def __call__(
         self: "ClasswiseScorer",
         model: SupervisedModel,
-        x_test: NDArray[np.float_],
+        x_test: NDArray[np.float64],
         y_test: NDArray[np.int_],
     ) -> float:
         (
@@ -180,7 +180,7 @@ class ClasswiseScorer(Scorer):
     def estimate_in_class_and_out_of_class_score(
         self,
         model: SupervisedModel,
-        x_test: NDArray[np.float_],
+        x_test: NDArray[np.float64],
         y_test: NDArray[np.int_],
         rescale_scores: bool = True,
     ) -> Tuple[float, float]:

--- a/src/pydvl/value/shapley/gt.py
+++ b/src/pydvl/value/shapley/gt.py
@@ -49,7 +49,7 @@ __all__ = ["group_testing_shapley", "num_samples_eps_delta"]
 
 log = logging.getLogger(__name__)
 
-T = TypeVar("T", NDArray[np.float_], float)
+T = TypeVar("T", NDArray[np.float64], float)
 GTConstants = namedtuple("GTConstants", ["kk", "Z", "q", "q_tot", "T"])
 
 
@@ -266,7 +266,7 @@ def group_testing_shapley(
         results_it: Iterable[Tuple[NDArray, NDArray]]
     ) -> Tuple[NDArray, NDArray]:
         return np.concatenate(list(x[0] for x in results_it)).astype(
-            np.float_
+            np.float64
         ), np.concatenate(list(x[1] for x in results_it)).astype(np.int_)
 
     seed_sequence = ensure_seed_sequence(seed)

--- a/src/pydvl/value/shapley/knn.py
+++ b/src/pydvl/value/shapley/knn.py
@@ -73,7 +73,7 @@ def knn_shapley(u: Utility, *, progress: bool = True) -> ValuationResult:
     # closest to farthest
     _, indices = nns.kneighbors(u.data.x_test)
 
-    values: NDArray[np.float_] = np.zeros_like(u.data.indices, dtype=np.float_)
+    values: NDArray[np.float64] = np.zeros_like(u.data.indices, dtype=np.float64)
     n = len(u.data)
     yt = u.data.y_train
     iterator = enumerate(zip(u.data.y_test, indices), start=1)

--- a/src/pydvl/value/stopping.py
+++ b/src/pydvl/value/stopping.py
@@ -575,7 +575,7 @@ class HistoryDeviation(StoppingCriterion):
         pin_converged: If `True`, once an index has converged, it is pinned
     """
 
-    _memory: NDArray[np.float_]
+    _memory: NDArray[np.float64]
 
     def __init__(
         self,
@@ -666,7 +666,7 @@ class RankCorrelation(StoppingCriterion):
             raise ValueError("rtol must be in (0, 1)")
         self.rtol = rtol
         self.burn_in = burn_in
-        self._memory: NDArray[np.float_] | None = None
+        self._memory: NDArray[np.float64] | None = None
         self._corr = 0.0
         self._completion = 0.0
         self._iterations = 0

--- a/tests/influence/conftest.py
+++ b/tests/influence/conftest.py
@@ -45,10 +45,10 @@ def linear_model(problem_dimension: Tuple[int, int], condition_number: float):
 
 
 def linear_derivative_analytical(
-    linear_model: Tuple[NDArray[np.float_], NDArray[np.float_]],
-    x: NDArray[np.float_],
-    y: NDArray[np.float_],
-) -> NDArray[np.float_]:
+    linear_model: Tuple[NDArray[np.float64], NDArray[np.float64]],
+    x: NDArray[np.float64],
+    y: NDArray[np.float64],
+) -> NDArray[np.float64]:
     """
     Given a linear model it returns the first order derivative wrt its parameters.
     More precisely, given a couple of matrices $A(\theta)$ and $b(\theta')$, with
@@ -71,10 +71,10 @@ def linear_derivative_analytical(
 
 
 def linear_hessian_analytical(
-    linear_model: Tuple[NDArray[np.float_], NDArray[np.float_]],
-    x: NDArray[np.float_],
+    linear_model: Tuple[NDArray[np.float64], NDArray[np.float64]],
+    x: NDArray[np.float64],
     lam: float = 0.0,
-) -> NDArray[np.float_]:
+) -> NDArray[np.float64]:
     """
     Given a linear model it returns the hessian wrt. its parameters.
     More precisely, given a couple of matrices $A(\theta)$ and $b(\theta')$, with
@@ -103,10 +103,10 @@ def linear_hessian_analytical(
 
 
 def linear_mixed_second_derivative_analytical(
-    linear_model: Tuple[NDArray[np.float_], NDArray[np.float_]],
-    x: NDArray[np.float_],
-    y: NDArray[np.float_],
-) -> NDArray[np.float_]:
+    linear_model: Tuple[NDArray[np.float64], NDArray[np.float64]],
+    x: NDArray[np.float64],
+    y: NDArray[np.float64],
+) -> NDArray[np.float64]:
     """
     Given a linear model it returns a second order partial derivative wrt its
     parameters .
@@ -137,13 +137,13 @@ def linear_mixed_second_derivative_analytical(
 
 
 def linear_analytical_influence_factors(
-    linear_model: Tuple[NDArray[np.float_], NDArray[np.float_]],
-    x: NDArray[np.float_],
-    y: NDArray[np.float_],
-    x_test: NDArray[np.float_],
-    y_test: NDArray[np.float_],
+    linear_model: Tuple[NDArray[np.float64], NDArray[np.float64]],
+    x: NDArray[np.float64],
+    y: NDArray[np.float64],
+    x_test: NDArray[np.float64],
+    y_test: NDArray[np.float64],
     hessian_regularization: float = 0,
-) -> NDArray[np.float_]:
+) -> NDArray[np.float64]:
     """
     Given a linear model it calculates its influence factors.
     :param linear_model: A tuple of arrays representing the linear model.
@@ -165,13 +165,13 @@ def linear_analytical_influence_factors(
 
 
 def add_noise_to_linear_model(
-    linear_model: Tuple[NDArray[np.float_], NDArray[np.float_]],
+    linear_model: Tuple[NDArray[np.float64], NDArray[np.float64]],
     train_set_size: int,
     test_set_size: int,
     noise: float = 0.01,
 ) -> Tuple[
-    Tuple[NDArray[np.float_], NDArray[np.float_]],
-    Tuple[NDArray[np.float_], NDArray[np.float_]],
+    Tuple[NDArray[np.float64], NDArray[np.float64]],
+    Tuple[NDArray[np.float64], NDArray[np.float64]],
 ]:
     A, b = linear_model
     o_d, i_d = tuple(A.shape)
@@ -199,11 +199,11 @@ def add_noise_to_linear_model(
 
 
 def analytical_linear_influences(
-    linear_model: Tuple[NDArray[np.float_], NDArray[np.float_]],
-    x: NDArray[np.float_],
-    y: NDArray[np.float_],
-    x_test: NDArray[np.float_],
-    y_test: NDArray[np.float_],
+    linear_model: Tuple[NDArray[np.float64], NDArray[np.float64]],
+    x: NDArray[np.float64],
+    y: NDArray[np.float64],
+    x_test: NDArray[np.float64],
+    y_test: NDArray[np.float64],
     mode: InfluenceMode = InfluenceMode.Up,
     hessian_regularization: float = 0,
 ):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -31,19 +31,17 @@ def dummy_values(values, names):
 )
 def test_sorting(values, names, ranks_asc, dummy_values):
     dummy_values.sort(key="value")
-    assert all([it.value for it in dummy_values] == sorted(values))
-    assert all(dummy_values.indices == ranks_asc)
-    assert all(
-        [it.value for it in reversed(dummy_values)] == sorted(values, reverse=True)
-    )
+    assert [it.value for it in dummy_values] == sorted(values)
+    assert dummy_values.indices.tolist() == ranks_asc
+    assert [it.value for it in reversed(dummy_values)] == sorted(values, reverse=True)
 
     dummy_values.sort(reverse=True)
-    assert all([it.value for it in dummy_values] == sorted(values, reverse=True))
-    assert all(dummy_values.indices == list(reversed(ranks_asc)))
+    assert [it.value for it in dummy_values] == sorted(values, reverse=True)
+    assert dummy_values.indices.tolist() == list(reversed(ranks_asc))
 
     dummy_values.sort(key="index")
-    assert all(dummy_values.indices == list(range(len(values))))
-    assert all([it.value for it in dummy_values] == values)
+    assert dummy_values.indices.tolist() == list(range(len(values)))
+    assert [it.value for it in dummy_values] == values
 
 
 @pytest.mark.parametrize(

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -385,7 +385,7 @@ def test_adding_different_indices(
     [
         ([0, 1, 2], np.int32, ["a", "b", "c"], "<U1"),
         ([4, 1, 7], np.int64, [4, 1, 7], np.int64),
-        ([4, 1, 7], np.int32, [4, 1, 7], np.float_),
+        ([4, 1, 7], np.int32, [4, 1, 7], np.float64),
     ],
 )
 def test_types(indices, index_t, data_names, name_t):
@@ -394,7 +394,7 @@ def test_types(indices, index_t, data_names, name_t):
 
     v = ValuationResult(
         indices=np.array(indices, dtype=index_t),
-        values=np.ones(len(indices), dtype=np.float_),
+        values=np.ones(len(indices), dtype=np.float64),
         data_names=np.array(data_names, dtype=name_t),
     )
     assert v.indices.dtype == index_t

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -31,19 +31,19 @@ def dummy_values(values, names):
 )
 def test_sorting(values, names, ranks_asc, dummy_values):
     dummy_values.sort(key="value")
-    assert np.alltrue([it.value for it in dummy_values] == sorted(values))
-    assert np.alltrue(dummy_values.indices == ranks_asc)
-    assert np.alltrue(
+    assert all([it.value for it in dummy_values] == sorted(values))
+    assert all(dummy_values.indices == ranks_asc)
+    assert all(
         [it.value for it in reversed(dummy_values)] == sorted(values, reverse=True)
     )
 
     dummy_values.sort(reverse=True)
-    assert np.alltrue([it.value for it in dummy_values] == sorted(values, reverse=True))
-    assert np.alltrue(dummy_values.indices == list(reversed(ranks_asc)))
+    assert all([it.value for it in dummy_values] == sorted(values, reverse=True))
+    assert all(dummy_values.indices == list(reversed(ranks_asc)))
 
     dummy_values.sort(key="index")
-    assert np.alltrue(dummy_values.indices == list(range(len(values))))
-    assert np.alltrue([it.value for it in dummy_values] == values)
+    assert all(dummy_values.indices == list(range(len(values))))
+    assert all([it.value for it in dummy_values] == values)
 
 
 @pytest.mark.parametrize(
@@ -55,16 +55,16 @@ def test_dataframe_sorting(values, names, ranks_asc, dummy_values):
         import pandas
 
         df = dummy_values.to_dataframe(use_names=False)
-        assert np.alltrue(df.index.values == ranks_asc)
+        assert all(df.index.values == ranks_asc)
 
         df = dummy_values.to_dataframe(use_names=True)
-        assert np.alltrue(df.index.values == sorted_names)
-        assert np.alltrue(df["dummy_valuator"].values == sorted(values))
+        assert all(df.index.values == sorted_names)
+        assert all(df["dummy_valuator"].values == sorted(values))
 
         dummy_values.sort(reverse=True)
         df = dummy_values.to_dataframe(use_names=True)
-        assert np.alltrue(df.index.values == list(reversed(sorted_names)))
-        assert np.alltrue(df["dummy_valuator"].values == sorted(values, reverse=True))
+        assert all(df.index.values == list(reversed(sorted_names)))
+        assert all(df["dummy_valuator"].values == sorted(values, reverse=True))
     except ImportError:
         pass
 
@@ -87,15 +87,15 @@ def test_todataframe(ranks_asc, dummy_values):
     df = dummy_values.to_dataframe()
     assert "dummy_valuator" in df.columns
     assert "dummy_valuator_stderr" in df.columns
-    assert np.alltrue(df.index.values == ranks_asc)
+    assert all(df.index.values == ranks_asc)
 
     df = dummy_values.to_dataframe(column="val")
     assert "val" in df.columns
     assert "val_stderr" in df.columns
-    assert np.alltrue(df.index.values == ranks_asc)
+    assert all(df.index.values == ranks_asc)
 
     df = dummy_values.to_dataframe(use_names=True)
-    assert np.alltrue(df.index.values == [it.name for it in dummy_values])
+    assert all(df.index.values == [it.name for it in dummy_values])
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_caching.py
+++ b/tests/utils/test_caching.py
@@ -328,7 +328,7 @@ def test_parallel_repeated_training(
         config=cached_func_config,
     )
 
-    def reduce_func(chunks: NDArray[np.float_]) -> float:
+    def reduce_func(chunks: NDArray[np.float64]) -> float:
         return np.sum(chunks).item()
 
     map_reduce_job = MapReduceJob(

--- a/tests/utils/test_numeric.py
+++ b/tests/utils/test_numeric.py
@@ -50,7 +50,7 @@ def test_random_powerset(n, max_subsets):
     counts are lower.
     """
     s = np.arange(n)
-    item_counts = np.zeros_like(s, dtype=np.float_)
+    item_counts = np.zeros_like(s, dtype=np.float64)
     size_counts = np.zeros(n + 1)
     for subset in random_powerset(s, n_samples=max_subsets):
         size_counts[len(subset)] += 1

--- a/tests/value/shapley/test_classwise.py
+++ b/tests/value/shapley/test_classwise.py
@@ -418,7 +418,7 @@ def dataset_manual_derivation() -> Dataset:
 @pytest.fixture(scope="function")
 def dataset_left_right_margins(
     n_element: int, left_margin: float, right_margin: float
-) -> Tuple[NDArray[np.float_], NDArray[np.int_], Dict[str, float]]:
+) -> Tuple[NDArray[np.float64], NDArray[np.int_], Dict[str, float]]:
     """
     The label set is represented as 0000011100011111, with adjustable left and right
     margins. The left margin denotes the percentage of zeros at the beginning, while the


### PR DESCRIPTION
### Description

This PR closes #603

### Changes

- Replace `np.float_` with `np.float64` and `np.alltrue` with `np.all`
- Add an upper bound (<2) to NumPy dependency

### Checklist

- [x] ~Wrote Unit tests (if necessary)~
- [x] ~Updated Documentation (if necessary)~
- [x] Updated Changelog
- [x] ~If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~
