### PR TITLE
Fix docs build

### DIFF
--- a/build_scripts/copy_changelog.py
+++ b/build_scripts/copy_changelog.py
@@ -14,25 +14,21 @@ target_filepath = docs_dir / changelog_file.name
 
 @mkdocs.plugins.event_priority(100)
 def on_pre_build(config):
-    logger.info("Temporarily copying changelog to docs directory")
+    logger.info("Link changelog to docs directory")
     try:
-        if os.path.getmtime(changelog_file) <= os.path.getmtime(target_filepath):
-            logger.info(
-                f"Changelog '{os.fspath(changelog_file)}' hasn't been updated, skipping."
-            )
-            return
-    except FileNotFoundError:
-        pass
-    logger.info(
-        f"Creating symbolic link for '{os.fspath(changelog_file)}' "
-        f"at '{os.fspath(target_filepath)}'"
-    )
-    target_filepath.symlink_to(changelog_file)
-
-    logger.info("Finished copying changelog to docs directory")
+        target_filepath.symlink_to(changelog_file)
+        logger.info(
+            f"Created symbolic link for '{os.fspath(changelog_file)}' "
+            f"at '{os.fspath(target_filepath)}'"
+        )
+    except FileExistsError:
+        logger.info(
+            f"File '{os.fspath(target_filepath)}' already exists, skipping symlink creation."
+        )
 
 
 @mkdocs.plugins.event_priority(-100)
 def on_shutdown():
-    logger.info("Removing temporary changelog in docs directory")
-    target_filepath.unlink()
+    pass  # Removing the link on shutdown makes mike fail the build
+    # logger.info("Removing temporary changelog in docs directory")
+    # target_filepath.unlink()

--- a/build_scripts/copy_contributing_guide.py
+++ b/build_scripts/copy_contributing_guide.py
@@ -14,25 +14,21 @@ target_filepath = docs_dir / contributing_file.name
 
 @mkdocs.plugins.event_priority(100)
 def on_pre_build(config):
-    logger.info("Temporarily copying contributing guide to docs directory")
+    logger.info("Linking contributing guide to docs directory")
     try:
-        if os.path.getmtime(contributing_file) <= os.path.getmtime(target_filepath):
-            logger.info(
-                f"Contributing guide '{os.fspath(contributing_file)}' hasn't been updated, skipping."
-            )
-            return
-    except FileNotFoundError:
-        pass
-    logger.info(
-        f"Creating symbolic link for '{os.fspath(contributing_file)}' "
-        f"at '{os.fspath(target_filepath)}'"
-    )
-    target_filepath.symlink_to(contributing_file)
-
-    logger.info("Finished copying contributing guide to docs directory")
+        target_filepath.symlink_to(contributing_file)
+        logger.info(
+            f"Created symbolic link for '{os.fspath(contributing_file)}' "
+            f"at '{os.fspath(target_filepath)}'"
+        )
+    except FileExistsError:
+        logger.info(
+            f"File '{os.fspath(target_filepath)}' already exists, skipping symlink creation."
+        )
 
 
 @mkdocs.plugins.event_priority(-100)
 def on_shutdown():
-    logger.info("Removing temporary contributing guide in docs directory")
-    target_filepath.unlink()
+    pass  # Removing the link on shutdown makes mike fail the build
+    # logger.info("Removing temporary contributing guide in docs directory")
+    # target_filepath.unlink()


### PR DESCRIPTION
<!--
Thanks for making a contribution! 
Please make sure you have read the contributing guide: 
https://github.com/aai-institute/pyDVL/blob/develop/CONTRIBUTING.md
-->

### Description

This PR fixes recent issues with doc builds. Since 2.1.0 mike runs the shutdown event of plugins. Our scripts `copy_changelog.py` and `copy_contributing_guide.py` would link the relevant files into `docs` then unlink them upon shutdown. mkdocs build would work but mike wouldn't see the files

### Changes

- Link the files and leave them there

### Checklist

- ~[ ] Wrote Unit tests (if necessary)~
- ~[ ] Updated Documentation (if necessary)~
- ~[ ] Updated Changelog~
- ~[ ] If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~
