### PR TITLE
Implement suppress_warnings decorator and use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 
 ### Fixed
 
+- Fixed `show_warnings=False` not being respected in subprocesses
+  [PR #647](https://github.com/aai-institute/pyDVL/pull/647)
 - Fixed several bugs in diverse stopping criteria, including: iteration counts,
   computing completion and resetting
   [PR #641](https://github.com/aai-institute/pyDVL/pull/641)

--- a/requirements-type-checking.txt
+++ b/requirements-type-checking.txt
@@ -1,4 +1,4 @@
-mypy==1.14
-types-tqdm
+mypy==1.15.0
+types-tqdm==4.67.0.20241221
 pandas-stubs
 -c requirements-constraints.txt

--- a/src/pydvl/utils/functional.py
+++ b/src/pydvl/utils/functional.py
@@ -1,14 +1,16 @@
 """
-Supporting utilities for manipulating arguments of functions.
+Supporting utilities for manipulating functions.
 """
 
 from __future__ import annotations
 
+import functools
 import inspect
+import warnings
 from functools import partial
-from typing import Callable, Set, Union
+from typing import Any, Callable, Optional, Sequence, Set, Type, TypeVar, Union
 
-__all__ = ["maybe_add_argument"]
+__all__ = ["maybe_add_argument", "suppress_warnings"]
 
 
 def _accept_additional_argument(*args, fun: Callable, arg: str, **kwargs):
@@ -106,3 +108,95 @@ def maybe_add_argument(fun: Callable, new_arg: str) -> Callable:
         return fun
 
     return partial(_accept_additional_argument, fun=fun, arg=new_arg)
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class WarningsSuppressor:
+    """A descriptor-based decorator to conditionally suppress warnings of a given
+    set of categories when the instance attribute (specified by `flag_attribute`) is
+    `False`.
+
+    It ensures that:
+      - The decorated function is an instance method (the first parameter must be
+        `self`).
+      - The instance possesses the attribute named by `flag_attribute` at call time.
+    """
+
+    def __init__(
+        self, func: F, categories: Sequence[Type[Warning]], flag_attribute: str
+    ) -> None:
+        functools.update_wrapper(self, func)
+        self.func = func
+        self.categories = categories
+        self.flag_attribute = flag_attribute
+
+        # HACK: Crappy heuristic to verify that the function is an instance method
+        #  At decoration time it's not yet bound, so we must resort to this sort of crap
+        sig = inspect.signature(func)
+        params = list(sig.parameters)
+        if not params or params[0] != "self":
+            raise TypeError(
+                "suppress_warnings decorator can only be applied to instance methods "
+                "(first parameter must be 'self')."
+            )
+
+    def __get__(
+        self, instance: Any, owner: Optional[Type[Any]] = None
+    ) -> Callable[..., Any]:
+        if instance is None:
+            return self  # Allow access via the class.
+
+        @functools.wraps(self.func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if getattr(instance, self.flag_attribute, False):
+                return self.func(instance, *args, **kwargs)
+            with warnings.catch_warnings():
+                for category in self.categories:
+                    warnings.simplefilter("ignore", category=category)
+                return self.func(instance, *args, **kwargs)
+
+        return wrapper
+
+
+def suppress_warnings(
+    categories: Sequence[Type[Warning]] = (Warning,), flag: str = "show_warnings"
+) -> Callable[[F], WarningsSuppressor]:
+    """
+    A decorator to suppress warnings in class methods.
+
+    ??? Example "Suppress all warnings"
+        ```python
+        class A:
+            @suppress_warnings()
+            def method(self, ...):
+                ...
+        ```
+    ??? Example "Suppress only `UserWarning`
+        ```python
+        class A:
+            def __init__(self, show_warnings: bool):
+                # the decorator will look for this attribute by default
+                self.show_warnings = show_warnings
+
+            @suppress_warnings(categories=(UserWarning,))
+            def method(self, ...):
+                ...
+        ```
+    ??? Example "Configuring behaviour at runtime"
+        ```python
+        class A:
+            def __init__(self, warn_enabled: bool)
+                self.warn_enabled = warn_enabled
+
+            @suppress_warnings(flag="warn_enabled")
+            def method(self, ...):
+                ....
+        ```
+    """
+
+    def wrapper(func: F) -> WarningsSuppressor:
+        return WarningsSuppressor(func, categories=categories, flag_attribute=flag)
+
+    return wrapper

--- a/src/pydvl/utils/functional.py
+++ b/src/pydvl/utils/functional.py
@@ -8,7 +8,7 @@ import functools
 import inspect
 import warnings
 from functools import partial
-from typing import Any, Callable, Optional, Sequence, Set, Type, TypeVar, Union
+from typing import Any, Callable, Optional, Sequence, Set, Type, TypeVar, Union, cast
 
 __all__ = ["maybe_add_argument", "suppress_warnings"]
 
@@ -146,7 +146,7 @@ class WarningsSuppressor:
         self, instance: Any, owner: Optional[Type[Any]] = None
     ) -> Callable[..., Any]:
         if instance is None:
-            return self  # Allow access via the class.
+            return cast(Callable[..., Any], self)  # Allow access via the class.
 
         @functools.wraps(self.func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -162,7 +162,7 @@ class WarningsSuppressor:
 
 def suppress_warnings(
     categories: Sequence[Type[Warning]] = (Warning,), flag: str = "show_warnings"
-) -> Callable[[F], WarningsSuppressor]:
+) -> Callable[[F], F]:
     """
     A decorator to suppress warnings in class methods.
 
@@ -196,7 +196,9 @@ def suppress_warnings(
         ```
     """
 
-    def wrapper(func: F) -> WarningsSuppressor:
-        return WarningsSuppressor(func, categories=categories, flag_attribute=flag)
+    def wrapper(func: F) -> F:
+        return cast(
+            F, WarningsSuppressor(func, categories=categories, flag_attribute=flag)
+        )
 
     return wrapper

--- a/src/pydvl/utils/functional.py
+++ b/src/pydvl/utils/functional.py
@@ -127,7 +127,7 @@ class WarningsSuppressor:
     def __init__(
         self, func: F, categories: Sequence[Type[Warning]], flag_attribute: str
     ) -> None:
-        functools.update_wrapper(self, func)
+        functools.update_wrapper(cast(F, self), func)
         self.func = func
         self.categories = categories
         self.flag_attribute = flag_attribute

--- a/src/pydvl/valuation/samplers/base.py
+++ b/src/pydvl/valuation/samplers/base.py
@@ -7,6 +7,7 @@ See [pydvl.valuation.samplers][pydvl.valuation.samplers] for details.
 from __future__ import annotations
 
 import logging
+import warnings
 from abc import ABC, abstractmethod
 from typing import Callable, Generic, Protocol, TypeVar
 
@@ -127,7 +128,7 @@ class IndexSampler(ABC, Generic[ValueUpdateT]):
         is deactivated by default. Samplers must explicitly override the setter to
         signal that they support skipping indices.
         """
-        raise NotImplementedError(f"Cannot skip indices in {self.__class__.__name__}.")
+        warnings.warn(f"Cannot skip indices in {self.__class__.__name__}.")
 
     def interrupt(self):
         self._interrupted = True
@@ -337,6 +338,8 @@ class EvaluationStrategy(ABC, Generic[SamplerT, ValueUpdateT]):
         log_coefficient: Callable[[int, int], float] | None = None,
     ):
         self.utility = utility
+        # Used by the decorator suppress_warnings:
+        self.show_warnings = getattr(utility, "show_warnings", False)
         self.n_indices = (
             len(utility.training_data) if utility.training_data is not None else 0
         )

--- a/src/pydvl/valuation/samplers/msr.py
+++ b/src/pydvl/valuation/samplers/msr.py
@@ -31,6 +31,7 @@ from typing import Callable, List
 
 import numpy as np
 
+from pydvl.utils.functional import suppress_warnings
 from pydvl.utils.numeric import random_subset
 from pydvl.utils.types import Seed
 from pydvl.valuation.result import ValuationResult
@@ -225,6 +226,7 @@ class MSREvaluationStrategy(EvaluationStrategy[MSRSampler, MSRValueUpdate]):
     running means must be updated.
     """
 
+    @suppress_warnings(categories=(RuntimeWarning,), flag="show_warnings")
     def process(
         self, batch: SampleBatch, is_interrupted: NullaryPredicate
     ) -> List[MSRValueUpdate]:
@@ -244,6 +246,7 @@ class MSREvaluationStrategy(EvaluationStrategy[MSRSampler, MSRValueUpdate]):
         updates = []
         for i, in_sample in enumerate(mask):  # type: int, bool
             k = len(sample.subset) - int(in_sample)
-            update = self.log_correction(self.n_indices, k) + np.log(u * sign)
+            update = -np.inf if u == 0 else np.log(u * sign)
+            update += self.log_correction(self.n_indices, k)
             updates.append(MSRValueUpdate(np.int_(i), update, sign, in_sample))
         return updates

--- a/src/pydvl/valuation/samplers/permutation.py
+++ b/src/pydvl/valuation/samplers/permutation.py
@@ -26,6 +26,7 @@ from typing import Callable
 
 import numpy as np
 
+from pydvl.utils.functional import suppress_warnings
 from pydvl.utils.numeric import logcomb
 from pydvl.utils.types import Seed
 from pydvl.valuation.samplers.base import (
@@ -169,6 +170,7 @@ class PermutationEvaluationStrategy(
         self.truncation = copy(sampler.truncation)
         self.truncation.reset(utility)  # Perform initial setup (e.g. total_utility)
 
+    @suppress_warnings(categories=(RuntimeWarning,), flag="show_warnings")
     def process(
         self, batch: SampleBatch, is_interrupted: NullaryPredicate
     ) -> list[ValueUpdate]:

--- a/tests/utils/test_functional.py
+++ b/tests/utils/test_functional.py
@@ -1,0 +1,120 @@
+import warnings
+from typing import Any, Type
+
+import numpy as np
+import pytest
+
+from pydvl.utils.functional import suppress_warnings
+
+
+class WarningsClass:
+    def __init__(self, show_warnings: bool = True):
+        self.show_warnings = show_warnings
+
+    @suppress_warnings(categories=(UserWarning,))
+    def method_warn(self) -> str:
+        warnings.warn("User warning", UserWarning)
+        return "done"
+
+    @suppress_warnings(categories=(DeprecationWarning,))
+    def method_deprecation(self) -> str:
+        warnings.warn("Deprecated", DeprecationWarning)
+        return "done"
+
+    @suppress_warnings(categories=(RuntimeWarning,))
+    def division_by_zero(self) -> float:
+        # This will trigger a RuntimeWarning from numpy.
+        return np.log(0)
+
+    @suppress_warnings()
+    def runtime_warning_no_explicit_category(self) -> float:
+        return np.log(0)
+
+
+def test_warning_shown(recwarn: Any):
+    # When show_warnings is True, the warning should be emitted.
+    obj = WarningsClass(show_warnings=True)
+    result = obj.method_warn()
+    assert result == "done"
+
+    # recwarn captures warnings issued during the test.
+    w = recwarn.pop(UserWarning)
+    assert "User warning" in str(w.message)
+    assert not recwarn  # Ensure no extra warnings were issued.
+
+
+def test_warning_suppressed():
+    # When show_warnings is False, the warning should be suppressed.
+    obj = WarningsClass(show_warnings=False)
+    with warnings.catch_warnings(record=True) as record:
+        result = obj.method_warn()
+        assert result == "done"
+        assert len(record) == 0
+
+
+def test_any_warning_suppressed():
+    obj = WarningsClass(show_warnings=False)
+    with warnings.catch_warnings(record=True) as record:
+        result = obj.runtime_warning_no_explicit_category()
+        assert result == -np.inf
+        assert len(record) == 0
+
+
+@pytest.mark.parametrize(
+    "method_name, category, warning_message",
+    [
+        ("method_warn", UserWarning, "User warning"),
+        ("method_deprecation", DeprecationWarning, "Deprecated"),
+    ],
+)
+def test_different_categories(
+    method_name: str, category: Type[Warning], warning_message: str, recwarn: Any
+):
+    obj = WarningsClass(show_warnings=True)
+    method = getattr(obj, method_name)
+    result = method()
+    assert result == "done"
+    w = recwarn.pop(category)
+    assert warning_message in str(w.message)
+
+
+def test_invalid_decorator_usage():
+    # Applying the decorator to a function that is not an instance method should raise a TypeError.
+    with pytest.raises(TypeError):
+
+        @suppress_warnings(categories=(UserWarning,))
+        def not_a_method(x: int) -> int:
+            return x
+
+
+class MultiWarningClass:
+    def __init__(self, warn_flag: bool = True):
+        self.warn_flag = warn_flag
+
+    @suppress_warnings(categories=(UserWarning, DeprecationWarning), flag="warn_flag")
+    def multi_warning(self) -> str:
+        warnings.warn("User warning", UserWarning)
+        warnings.warn("Deprecated", DeprecationWarning)
+        return "done"
+
+
+def test_multi_warning_shown(recwarn: Any):
+    # With the custom flag True, both warnings should be issued.
+    obj = MultiWarningClass(warn_flag=True)
+    result = obj.multi_warning()
+    assert result == "done"
+    w1 = recwarn.pop(UserWarning)
+    assert "User warning" in str(w1.message)
+    w2 = recwarn.pop(DeprecationWarning)
+    assert "Deprecated" in str(w2.message)
+    assert not recwarn
+
+
+def test_multi_warning_suppressed():
+    # With the custom flag False, both warnings should be suppressed.
+    obj = MultiWarningClass(warn_flag=False)
+    with warnings.catch_warnings(record=True) as record:
+        result = obj.multi_warning()
+        assert result == "done"
+        # No warnings should be recorded.
+        assert len(record) == 0


### PR DESCRIPTION
<!--
Thanks for making a contribution! 
Please make sure you have read the contributing guide: 
https://github.com/aai-institute/pyDVL/blob/develop/CONTRIBUTING.md
-->

### Description

This PR  fixes `show_warnings=False` not being respected in subprocesses.

### Changes

- Implements a decorator `suppress_warnings` to be used with class methods. It can check for a flag in the object at runtime in order to enable or disable warnings. Warning categories are configurable

### Checklist

- [x] Wrote Unit tests (if necessary)
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- ~[ ] If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~
