### PR TITLE
Fix/result slicing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@
 
 ### Changed
 
+- Slicing, comparing and setting of `ValuationResult` behave in a more 
+  natural way
+  [PR #660](https://github.com/aai-institute/pyDVL/pull/660)
 - Switched all semi-value coefficients and sampler weights to log-space in
   order to avoid overflows
   [PR #643](https://github.com/aai-institute/pyDVL/pull/643)

--- a/src/pydvl/valuation/result.py
+++ b/src/pydvl/valuation/result.py
@@ -2,46 +2,64 @@
 This module collects types and methods for the inspection of the results of
 valuation algorithms.
 
-The most important class is [ValuationResult][pydvl.valuation.result.ValuationResult], which
-provides access to raw values, as well as convenient behaviour as a `Sequence` with
-extended indexing and updating abilities, and conversion to [pandas
+The most important class is [ValuationResult][pydvl.valuation.result.ValuationResult],
+which provides access to raw values, as well as convenient behaviour as a `Sequence`
+with extended indexing and updating abilities, and conversion to [pandas
 DataFrames][pandas.DataFrame].
 
-# Operating on results
+## Indexing and slicing
+
+Indexing and slicing of results is supported in a natural way and
+[ValuationResult][pydvl.valuation.result.ValuationResult] objects are returned. Indexing
+follows the sorting order. See the class documentation for more on this.
+
+Setting items and slices is also possible with other valuation results. Index and name
+clashes are detected and raise an exception. Note that any sorted state is potentially
+lost when setting items or slices.
+
+## Addition
 
 Results can be added together with the standard `+` operator. Because values
 are typically running averages of iterative algorithms, addition behaves like a
 weighted average of the two results, with the weights being the number of
 updates in each result: adding two results is the same as generating one result
 with the mean of the values of the two results as values. The variances are
-updated accordingly. See [ValuationResult][pydvl.valuation.result.ValuationResult] for details.
+updated accordingly. See [ValuationResult][pydvl.valuation.result.ValuationResult] for
+details.
 
-Results can also be sorted by value, variance or number of updates, see
-[sort()][pydvl.valuation.result.ValuationResult.sort]. The arrays of
+## Comparing
+
+Results can be compared with the equality operator. The comparison is "semantic" in the
+sense that it's the valuation for data indices that matters and not the order in which
+they are in the `ValuationResult`. Values, variances and counts are compared.
+
+## Sorting
+
+Results can also be sorted **in place** by value, variance or number of updates, see
+[sort()][pydvl.valuation.result.ValuationResult.sort]. All the properties
 [ValuationResult.values][pydvl.valuation.result.ValuationResult.values],
 [ValuationResult.variances][pydvl.valuation.result.ValuationResult.variances],
 [ValuationResult.counts][pydvl.valuation.result.ValuationResult.counts],
 [ValuationResult.indices][pydvl.valuation.result.ValuationResult.indices],
 [ValuationResult.stderr][pydvl.valuation.result.ValuationResult.stderr],
 [ValuationResult.names][pydvl.valuation.result.ValuationResult.names]
-are sorted in the same way.
+are then sorted according to the same order.
 
-Indexing and slicing of results is supported and
-[ValueItem][pydvl.valuation.result.ValueItem] objects are returned. These objects
-can be compared with the usual operators, which take only the
-[ValueItem.value][pydvl.valuation.result.ValueItem] into account.
 
-# Creating result objects
+## Factories
 
-The most commonly used factory method is
+Besides [copy()][pydvl.valuation.result.ValuationResult.copy],the most commonly used
+factory method is
 [ValuationResult.zeros()][pydvl.valuation.result.ValuationResult.zeros], which
 creates a result object with all values, variances and counts set to zero.
+
 [ValuationResult.empty()][pydvl.valuation.result.ValuationResult.empty] creates an
 empty result object, which can be used as a starting point for adding results
-together. Empty results are discarded when added to other results. Finally,
+together. **Any metadata in empty results is discarded when added to other results.**
+
+Finally,
 [ValuationResult.from_random()][pydvl.valuation.result.ValuationResult.from_random]
 samples random values uniformly.
-
 """
 
 from __future__ import annotations
@@ -140,15 +158,15 @@ class ValuationResult(collections.abc.Sequence, Iterable[ValueItem]):
 
     ## Indexing
 
-    Indexing can be position-based, when accessing any of the attributes
+    Indexing is sort-based, when accessing any of the attributes
     [values][pydvl.valuation.result.ValuationResult.values],
     [variances][pydvl.valuation.result.ValuationResult.variances],
     [counts][pydvl.valuation.result.ValuationResult.counts] and
     [indices][pydvl.valuation.result.ValuationResult.indices], as well as when iterating
     over the object, or using the item access operator, both getter and setter. The
     "position" is either the original sequence in which the data was passed to the
-    constructor, or the sequence in which the object is sorted, see below.
-    One can retrieve the position for a given data index using the method
+    constructor, or the sequence in which the object has been sorted, see below.
+    One can retrieve the sorted position for a given data index using the method
     [positions()][pydvl.valuation.result.ValuationResult.positions].
 
     Some methods use data indices instead. This is the case for
@@ -181,12 +199,9 @@ class ValuationResult(collections.abc.Sequence, Iterable[ValueItem]):
 
     ## Operating on results
 
-    Results can be added to each other with the `+` operator. Means and
-    variances are correctly updated, using the `counts` attribute.
-
-    Results can also be updated with new values using
-    [update()][pydvl.valuation.result.ValuationResult.update]. Means and variances are
-    updated accordingly using the Welford algorithm.
+    Results can be added to each other with the `+` operator or updated with new values
+    using [update()][pydvl.valuation.result.ValuationResult.update]. Means and variances
+    are correctly updated accordingly using the Welford algorithm.
 
     Empty objects behave in a special way, see
     [empty()][pydvl.valuation.result.ValuationResult.empty].
@@ -216,7 +231,7 @@ class ValuationResult(collections.abc.Sequence, Iterable[ValueItem]):
          ValueError: If input arrays have mismatching lengths.
 
     ??? tip "Changed in 0.10.0"
-        Changed the behaviour of the `sort` argument.
+        Changed the behaviour of sorting, slicing, and indexing.
     """
 
     _indices: NDArray[IndexT]

--- a/src/pydvl/valuation/samplers/base.py
+++ b/src/pydvl/valuation/samplers/base.py
@@ -36,7 +36,7 @@ __all__ = ["EvaluationStrategy", "IndexSampler", "ResultUpdater"]
 logger = logging.getLogger(__name__)
 
 
-class ResultUpdater(Generic[ValueUpdateT]):
+class ResultUpdater(ABC, Generic[ValueUpdateT]):
     """Base class for result updaters.
 
     A result updater is a strategy to update a valuation result with a value update.
@@ -45,6 +45,7 @@ class ResultUpdater(Generic[ValueUpdateT]):
     def __init__(self, result: ValuationResult):
         self.result = result
 
+    @abstractmethod
     def __call__(self, update: ValueUpdateT) -> ValuationResult: ...
 
 

--- a/src/pydvl/valuation/samplers/base.py
+++ b/src/pydvl/valuation/samplers/base.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 import logging
 import warnings
 from abc import ABC, abstractmethod
-from typing import Callable, Generic, Protocol, TypeVar
+from typing import Callable, Generic, TypeVar
 
 import numpy as np
 from more_itertools import chunked
 
 from pydvl.utils import log_running_moments
 from pydvl.valuation.dataset import Dataset
-from pydvl.valuation.result import ValuationResult
+from pydvl.valuation.result import ValuationResult, ValueItem
 from pydvl.valuation.types import (
     BatchGenerator,
     IndexSetT,
@@ -36,13 +36,14 @@ __all__ = ["EvaluationStrategy", "IndexSampler", "ResultUpdater"]
 logger = logging.getLogger(__name__)
 
 
-class ResultUpdater(Protocol[ValueUpdateT]):
-    """Protocol for result updaters.
+class ResultUpdater(Generic[ValueUpdateT]):
+    """Base class for result updaters.
 
     A result updater is a strategy to update a valuation result with a value update.
     """
 
-    def __init__(self, result: ValuationResult): ...
+    def __init__(self, result: ValuationResult):
+        self.result = result
 
     def __call__(self, update: ValueUpdateT) -> ValuationResult: ...
 
@@ -270,7 +271,7 @@ class LogResultUpdater(ResultUpdater[ValueUpdateT]):
     """Updates a valuation result with a value update in log-space."""
 
     def __init__(self, result: ValuationResult):
-        self.result = result
+        super().__init__(result)
         self._log_sum_positive = np.full_like(result.values, -np.inf)
         self._log_sum_negative = np.full_like(result.values, -np.inf)
         self._log_sum2 = np.full_like(result.values, -np.inf)
@@ -283,7 +284,7 @@ class LogResultUpdater(ResultUpdater[ValueUpdateT]):
         except KeyError:
             raise IndexError(f"Index {update.idx} not found in ValuationResult")
 
-        item = self.result[loc]
+        item = self.result.get(update.idx)
 
         new_val, new_var, log_sum_pos, log_sum_neg, log_sum2 = log_running_moments(
             self._log_sum_positive[loc],
@@ -298,10 +299,15 @@ class LogResultUpdater(ResultUpdater[ValueUpdateT]):
         self._log_sum_negative[loc] = log_sum_neg
         self._log_sum2[loc] = log_sum2
 
-        item.value = new_val
-        item.variance = new_var
-        item.count = item.count + 1 if item.count is not None else 1
-        self.result[loc] = item
+        updated_item = ValueItem(
+            idx=item.idx,
+            name=item.name,
+            value=new_val,
+            variance=new_var,
+            count=item.count + 1 if item.count is not None else 1
+        )
+
+        self.result.set(item.idx, updated_item)
         return self.result
 
 

--- a/src/pydvl/valuation/samplers/base.py
+++ b/src/pydvl/valuation/samplers/base.py
@@ -304,7 +304,7 @@ class LogResultUpdater(ResultUpdater[ValueUpdateT]):
             name=item.name,
             value=new_val,
             variance=new_var,
-            count=item.count + 1 if item.count is not None else 1
+            count=item.count + 1 if item.count is not None else 1,
         )
 
         self.result.set(item.idx, updated_item)

--- a/src/pydvl/valuation/utility/deepset.py
+++ b/src/pydvl/valuation/utility/deepset.py
@@ -123,7 +123,7 @@ class DeepSet(nn.Module):
         phi_x = self.phi(x)  # shape: (batch_size, set_size, phi_output_dim)
         aggregated = torch.sum(phi_x, dim=1)  # shape: (batch_size, phi_output_dim)
         out = self.rho(aggregated)  # shape: (batch_size, 1)
-        return out
+        return cast(Tensor, out)
 
 
 class SetDatasetRaw(TorchDataset):
@@ -132,7 +132,7 @@ class SetDatasetRaw(TorchDataset):
         samples: dict[Sample, float],
         training_data: Dataset,
         dtype: torch.dtype = torch.float32,
-        device: torch.device = "cpu",
+        device: torch.device | str = "cpu",
     ):
         """
         Args:

--- a/tests/valuation/methods/test_deterministic_shapley.py
+++ b/tests/valuation/methods/test_deterministic_shapley.py
@@ -238,4 +238,4 @@ def test_polynomial_with_outlier(
 
     check_total_value(poly_utility.with_dataset(data_train), values, atol=total_atol)
 
-    assert values[0].idx == outlier_idx
+    assert values.get(0).idx == outlier_idx

--- a/tests/valuation/test_result.py
+++ b/tests/valuation/test_result.py
@@ -12,6 +12,7 @@ from numpy.typing import NDArray
 
 from pydvl.utils.status import Status
 from pydvl.valuation import ValuationResult
+from pydvl.valuation.result import ValueItem
 
 
 @pytest.fixture
@@ -24,6 +25,55 @@ def dummy_values(values, names):
         data_names=names,
         sort=True,
     )
+
+
+def test_valueitem_comparison():
+    v1 = ValueItem(idx=0, name="a", value=1.0, variance=0.0, count=1)
+    v2 = ValueItem(idx=0, name="a", value=1.0, variance=0.0, count=1)
+    v3 = ValueItem(idx=1, name="b", value=2.0, variance=0.0, count=1)
+    v4 = ValueItem(idx=1, name="b", value=3.0, variance=0.0, count=1)
+
+    assert v1 == v2
+    assert v1 != v3
+    assert v3 < v4
+    assert v4 > v3
+    assert v3 <= v4
+    assert v4 >= v3
+
+    with pytest.raises(TypeError, match="Cannot compare ValueItem with"):
+        v1 == 1.0  # noqa
+
+
+def test_creation():
+    values = np.array([1.0, 2.0, 3.0])
+    indices = np.array([0, 1, 2])
+    v = ValuationResult(values=values, indices=indices)
+    assert len(v) == len(values)
+    assert np.all(v.values == values)
+    assert np.all(v.indices == indices)
+
+    v = ValuationResult(values=values, indices=indices, sort=False)
+    assert len(v) == len(values)
+    assert np.all(v.values == values[::-1])
+    assert np.all(v.indices == indices[::-1])
+
+    with pytest.raises(
+        ValueError, match=r"Lengths of values \(3\) and indices \(2\) do not match"
+    ):
+        v = ValuationResult(values=values, indices=np.array([0, 1]))
+
+    with pytest.raises(
+        ValueError, match=r"Lengths of values \(3\) and variances \(2\) do not match"
+    ):
+        v = ValuationResult(values=values, variances=np.array([0, 1]))
+
+    with pytest.raises(
+        ValueError, match=r"Lengths of values \(3\) and data_names \(1\) do not match"
+    ):
+        v = ValuationResult(values=values, data_names=["d"])
+
+    with pytest.raises(ValueError, match="Data names must be unique"):
+        v = ValuationResult(values=values, data_names=["a", "b", "a"])
 
 
 @pytest.mark.parametrize(
@@ -111,16 +161,49 @@ def test_indexing(ranks_asc, dummy_values):
     if len(ranks_asc) == 0:
         with pytest.raises(IndexError):
             dummy_values[1]  # noqa
-        dummy_values[:2]  # noqa
+        empty_slice = dummy_values[:2]  # noqa
+        assert isinstance(empty_slice, ValuationResult)
+        assert len(empty_slice) == 0
     else:
-        assert ranks_asc[:] == [it.idx for it in dummy_values[:]]
-        assert ranks_asc[0] == dummy_values[0].idx
-        assert [ranks_asc[0]] == [it.idx for it in dummy_values[[0]]]
-        assert ranks_asc[:2] == [it.idx for it in dummy_values[:2]]
-        assert ranks_asc[:2] == [it.idx for it in dummy_values[[0, 1]]]
-        assert ranks_asc[:-2] == [it.idx for it in dummy_values[:-2]]
-        assert ranks_asc[-2:] == [it.idx for it in dummy_values[-2:]]
-        assert ranks_asc[-2:] == [it.idx for it in dummy_values[[-2, -1]]]
+        # Test that indexing returns ValuationResult objects
+        single_idx_result = dummy_values[0]
+        assert isinstance(single_idx_result, ValuationResult)
+        assert len(single_idx_result) == 1
+        assert single_idx_result.indices[0] == ranks_asc[0]
+
+        # Test list indexing
+        list_idx_result = dummy_values[[0]]
+        assert isinstance(list_idx_result, ValuationResult)
+        assert len(list_idx_result) == 1
+        assert list_idx_result.indices[0] == ranks_asc[0]
+
+        # Test slice indexing
+        slice_idx_result = dummy_values[:2]
+        assert isinstance(slice_idx_result, ValuationResult)
+        assert len(slice_idx_result) == 2
+        assert np.all(slice_idx_result.indices == ranks_asc[:2])
+
+        # Test multiple indexing
+        multi_idx_result = dummy_values[[0, 1]]
+        assert isinstance(multi_idx_result, ValuationResult)
+        assert len(multi_idx_result) == 2
+        assert np.all(multi_idx_result.indices == ranks_asc[:2])
+
+        # Test negative indexing
+        neg_slice_result = dummy_values[-2:]
+        assert isinstance(neg_slice_result, ValuationResult)
+        assert len(neg_slice_result) == 2
+        assert np.all(neg_slice_result.indices == ranks_asc[-2:])
+
+        # Test negative list indexing
+        neg_list_result = dummy_values[[-2, -1]]
+        assert isinstance(neg_list_result, ValuationResult)
+        assert len(neg_list_result) == 2
+        assert np.all(neg_list_result.indices == ranks_asc[-2:])
+
+        # Verify metadata is copied
+        assert single_idx_result.algorithm == dummy_values.algorithm
+        assert single_idx_result.status == dummy_values.status
 
 
 def test_get_idx():
@@ -176,6 +259,9 @@ def test_updating():
     np.testing.assert_allclose(v.values, [3, 0.5])
     np.testing.assert_allclose(v.variances, [0.0, 0.5])
 
+    with pytest.raises(IndexError, match="not found in ValuationResult"):
+        v.update(5, 1.0)
+
 
 def test_updating_order_invariance():
     updates = [0.8, 0.9, 1.0, 1.1, 1.2]
@@ -199,8 +285,10 @@ def test_updating_order_invariance():
 def test_serialization(serialize, deserialize, dummy_values):
     serded = deserialize(serialize(dummy_values))
     assert dummy_values == serded  # Serialization OK (if __eq__ ok...)
-    dummy_values.sort(reverse=True)
-    assert dummy_values != serded  # Order checks
+    if len(dummy_values) > 0:
+        # Sorting only has an effect over equality on non-empty results
+        dummy_values.sort(reverse=True)
+        assert dummy_values != serded  # Order checks
 
 
 @pytest.mark.parametrize("values, names", [([], []), ([2, 3, 1], ["a", "b", "c"])])
@@ -209,7 +297,9 @@ def test_copy_and_equality(values, names, dummy_values):
 
     c = dummy_values.copy()
     dummy_values.sort(reverse=True)
-    assert c != dummy_values
+
+    if len(c) > 0:  # Sorting only has an effect over equality on non-empty results
+        assert c != dummy_values
 
     c2 = ValuationResult(
         algorithm="dummy",
@@ -272,6 +362,139 @@ def test_extra_values(extra_values):
         assert k in repr_string
 
 
+@pytest.mark.parametrize(
+    "extra_values", [{"test_value": 1.2}, {"test_value1": 1.2, "test_value2": "test"}]
+)
+def test_extra_values_preserved_in_indexing(extra_values):
+    """Test that extra values are preserved when indexing."""
+    kwargs = dict(
+        algorithm="test",
+        status=Status.Converged,
+        values=np.random.rand(10),
+        sort=True,
+    )
+    kwargs.update(extra_values)
+    result = ValuationResult(**kwargs)
+
+    # Test single indexing
+    single_result = result[0]
+    for k, v in extra_values.items():
+        assert getattr(single_result, k) == v
+
+    # Test slice indexing
+    slice_result = result[:5]
+    for k, v in extra_values.items():
+        assert getattr(slice_result, k) == v
+
+    # Test list indexing
+    list_result = result[[0, 1, 2]]
+    for k, v in extra_values.items():
+        assert getattr(list_result, k) == v
+
+
+def test_set_method():
+    """Test the set method for setting ValueItems by data index."""
+    values = np.array([1.0, 2.0, 3.0])
+    indices = np.array([10, 20, 30])
+    result = ValuationResult(values=values, indices=indices)
+
+    new_item = ValueItem(
+        idx=20,  # Must match an existing index
+        name="test_name",
+        value=5.0,
+        variance=0.5,
+        count=3,
+    )
+
+    result.set(20, new_item)
+    assert result.get(20) == new_item
+
+    mismatched_item = ValueItem(
+        idx=50,  # Doesn't match data_idx we're setting
+        name="mismatch",
+        value=9.0,
+        variance=1.0,
+        count=1,
+    )
+
+    with pytest.raises(ValueError, match="doesn't match the provided data_idx"):
+        result.set(20, mismatched_item)
+
+    with pytest.raises(IndexError, match="not found in ValuationResult"):
+        result.set(50, mismatched_item)
+
+
+def test_get_and_setitem():
+    r1 = ValuationResult(
+        indices=np.array([10, 20, 30, 40]),
+        values=np.array([1.0, 2.0, 3.0, 4.0]),
+        data_names=np.array(["a", "b", "c", "d"]),
+    )
+
+    r2 = ValuationResult(
+        indices=np.array([50, 60]),
+        values=np.array([5.0, 6.0]),
+        data_names=np.array(["e", "f"]),
+    )
+
+    r1[:2] = r2
+    # test indexing with slices and iterables too
+    assert r1[slice(0, 2)] == r2[[0, 1]]
+
+    # Original state at other positions should be unchanged
+    assert all(r1.indices[2:] == [30, 40])  # noqa
+    assert all(r1.values[2:] == [3.0, 4.0])  # noqa
+    assert all(r1.names[2:] == ["c", "d"])  # noqa
+
+    r2.sort(reverse=True, key="value")
+    r1[[0, 1]] = r2
+    assert all(r1.indices[:2] == [60, 50])  # noqa
+    assert all(r1.values[:2] == [6.0, 5.0])  # noqa
+    assert all(r1.names[:2] == ["f", "e"])  # noqa
+
+    with pytest.raises(ValueError, match="Operation would result in duplicate indices"):
+        r1[2:] = r2
+
+    with pytest.raises(ValueError, match="Operation would result in duplicate names"):
+        r1[0] = ValuationResult(
+            indices=np.array([80]), values=np.array([8.0]), data_names=np.array(["e"])
+        )
+
+    r1.sort(key="index")
+    r3 = r1[::-1]
+    r1.sort(reverse=True, key="index")
+    assert r3 == r1
+
+    # Test negative indexing
+    r3[-1] = r1[3]
+    r3[-2] = r1[2]
+    assert r3 == r1
+
+    assert r3[3] == r1[-1]
+    assert r3[2] == r1[-2]
+
+    # Test error when lengths don't match
+    with pytest.raises(ValueError, match="Cannot set .* positions"):
+        r1[:3] = r2
+
+    # Test error when not ValuationResult
+    with pytest.raises(TypeError, match="Value must be a ValuationResult"):
+        r1[0] = ValueItem(idx=0, name="test", value=1.0, variance=0.0, count=1)  # type: ignore
+
+    # Test index types
+    with pytest.raises(TypeError, match="Indices must be"):
+        r1["a"]  # noqa
+
+    with pytest.raises(TypeError, match="Indices must be"):
+        r1["a"] = r2[0]  # noqa
+
+    with pytest.raises(IndexError, match=r"Index 5 out of range \(0, 4\)"):
+        r1[5]  # noqa
+
+    with pytest.raises(IndexError, match=r"Index 5 out of range \(0, 4\)"):
+        r1[5] = r2[0]
+
+
 @pytest.mark.parametrize("size", [1, 10])
 @pytest.mark.parametrize("total", [None, 1.0, -1.0])
 def test_from_random_creation(size: int, total: float | None):
@@ -288,6 +511,26 @@ def test_from_random_creation_errors():
         ValuationResult.from_random(size=0)
 
 
+def test_addition_compatibility():
+    v1 = ValuationResult.from_random(size=4)
+    with pytest.raises(TypeError, match="Cannot combine ValuationResult with"):
+        v1 += 1
+    v2 = ValuationResult.from_random(size=4, algorithm="blah")  # noqa
+    with pytest.raises(ValueError, match="Cannot combine results from"):
+        v1 += v2
+
+
+def test_equality_compatibility():
+    v = ValuationResult.empty(algorithm="foo", status=Status.Pending)  # noqa
+
+    with pytest.raises(TypeError, match="Cannot compare"):
+        v == 1  # noqa
+
+    assert not v == ValuationResult.from_random(3)
+    assert not v == ValuationResult.empty(algorithm="bar")
+    assert not v == ValuationResult.empty(algorithm="foo", status=Status.Converged)  # noqa
+
+
 def test_adding_random():
     """Test adding multiple valuation results together.
 
@@ -296,9 +539,9 @@ def test_adding_random():
     results together and check that the resulting means and variances match with
     those of the original matrix.
     """
-    n_samples, n_values, n_subsets = 10, 1000, 12
-    values = np.random.rand(n_samples, n_values)
-    split_indices = np.sort(np.random.randint(1, n_values, size=n_subsets - 1))
+    n_data, n_values, n_splits = 10, 1000, 12
+    values = np.random.rand(n_data, n_values)
+    split_indices = np.sort(np.random.randint(1, n_values, size=n_splits - 1))
     splits = np.split(values, split_indices, axis=1)
     vv = [
         ValuationResult(
@@ -306,7 +549,7 @@ def test_adding_random():
             status=Status.Pending,
             values=np.average(s, axis=1),
             variances=np.var(s, axis=1),
-            counts=s.shape[1] * np.ones(n_samples),
+            counts=np.full(s.shape[0], fill_value=s.shape[1]),
         )
         for s in splits
     ]
@@ -314,11 +557,13 @@ def test_adding_random():
 
     true_means = values.mean(axis=1)
     true_variances = values.var(axis=1)
+    true_stderr = values.std(axis=1) / np.sqrt(n_values)
 
     np.testing.assert_allclose(true_means[result.indices], result.values, atol=1e-5)
     np.testing.assert_allclose(
         true_variances[result.indices], result.variances, atol=1e-5
     )
+    np.testing.assert_allclose(true_stderr[result.indices], result.stderr, atol=1e-5)
 
 
 @pytest.mark.parametrize(
@@ -442,10 +687,11 @@ def test_names(data_names):
     assert np.all(v.names == np.array(data_names))
 
 
+@pytest.mark.parametrize("n_samples", [0, 3])
 @pytest.mark.parametrize("n", [0, 5])
-def test_empty(n):
-    v = ValuationResult.empty()
-    assert len(v) == 0
+def test_empty(n_samples: int, n: int):
+    v = ValuationResult.empty(n_samples=n_samples)
+    assert len(v) == n_samples
     v2 = ValuationResult(values=np.arange(n))
     v += v2
     assert len(v2) == n


### PR DESCRIPTION
<!--
Thanks for making a contribution! 
Please make sure you have read the contributing guide: 
https://github.com/aai-institute/pyDVL/blob/develop/CONTRIBUTING.md
-->

### Description

This PR closes #629 because it's now or never

### Changes

- Slicing does the only sane thing of returning new valuation results
- Setting with setitem also operates in the natural way
- Equality checks for results no longer look at internal bookkeeping, but only at the mapping data index -> value,variance, etc.
- Much more test coverage
- Little pesky bugs were squashed in the process

### Checklist

- [x] Wrote Unit tests (if necessary)
- [x] Updated Documentation (if necessary)
- [x] Updated Changelog
- ~[ ] If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~
