### PR TITLE
Switch to trusted publishing for pypi

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,8 +23,13 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-22.04
+    environment:
+      name: publish
+      url: https://pypi.org/pydvl
     concurrency:
       group: publish
+    permissions:
+      id-token: write
     steps:
       - name: Checking out last commit in release
         if: ${{ github.event_name != 'workflow_dispatch' }}
@@ -54,6 +59,11 @@ jobs:
           # Make the version available as env variable for next steps
           echo CURRENT_VERSION=$CURRENT_VERSION >> $GITHUB_ENV
         shell: bash
+      - name: Build dist
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
       - name: Deploy Docs
         uses: ./.github/actions/deploy-docs
         with:
@@ -63,10 +73,3 @@ jobs:
           email: ${{ env.GITHUB_BOT_EMAIL }}
           username: ${{ env.GITHUB_BOT_USERNAME }}
           set-default: 'true'
-      - name: Build and publish to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload --verbose --non-interactive dist/*

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,6 +64,9 @@ jobs:
           python setup.py sdist bdist_wheel
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          print-hash: true
       - name: Deploy Docs
         uses: ./.github/actions/deploy-docs
         with:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,4 +18,3 @@ pytest-sugar
 pytest-rerunfailures
 nbmake
 wheel
-twine==5.1.1


### PR DESCRIPTION
### Description

This PR mimics #665 for the main pypi repo

### Changes

- Ditches tokens and uses pypa's action
- Removes the twine dependency

### Checklist

- ~[ ] Wrote Unit tests (if necessary)~
- ~[ ] Updated Documentation (if necessary)~
- ~[ ] Updated Changelog~
- ~[ ] If notebooks were added/changed, added boilerplate cells are tagged with `"tags": ["hide"]` or `"tags": ["hide-input"]`~
